### PR TITLE
Branch v5.3.8

### DIFF
--- a/includes/class-wcj-global-discount.php
+++ b/includes/class-wcj-global-discount.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Global Discount
  *
- * @version 5.2.0
+ * @version 5.3.8
  * @since   2.5.7
  * @author  Pluggabl LLC.
  */
@@ -231,13 +231,17 @@ class WCJ_Global_Discount extends WCJ_Module {
 	/**
 	 * change_price.
 	 *
-	 * @version 3.1.0
+	 * @version 5.3.8
 	 * @since   3.1.0
 	 * @todo    `WCJ_PRODUCT_GET_REGULAR_PRICE_FILTER, 'woocommerce_variation_prices_regular_price', 'woocommerce_product_variation_get_regular_price'`
 	 */
 	function change_price( $price, $_product ) {
 		$_current_filter = current_filter();
 		if ( in_array( $_current_filter, array( WCJ_PRODUCT_GET_PRICE_FILTER, 'woocommerce_variation_prices_price', 'woocommerce_product_variation_get_price' ) ) ) {
+			if(isset($_product->wcj_wholesale_price)){
+
+				return $_product->wcj_wholesale_price;
+			}
 			return $this->add_global_discount( $price, $_product, 'price' );
 		} elseif ( in_array( $_current_filter, array( WCJ_PRODUCT_GET_SALE_PRICE_FILTER, 'woocommerce_variation_prices_sale_price', 'woocommerce_product_variation_get_sale_price' ) ) ) {
 			return $this->add_global_discount( $price, $_product, 'sale_price' );
@@ -355,6 +359,7 @@ class WCJ_Global_Discount extends WCJ_Module {
 	 * @since   2.5.7
 	 */
 	function add_global_discount( $price, $_product, $price_type ) {
+		
 		if ( 'price' === $price_type && '' === $price ) {
 			return $price; // no changes
 		}

--- a/includes/class-wcj-order-min-amount.php
+++ b/includes/class-wcj-order-min-amount.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Order Minimum Amount
  *
- * @version 5.2.0
+ * @version 5.3.8
  * @since   2.5.7
  * @author  Pluggabl LLC.
  * @todo    order max amount
@@ -39,7 +39,7 @@ class WCJ_Order_Min_Amount extends WCJ_Module {
 	/**
 	 * add_order_minimum_amount_hooks.
 	 *
-	 * @version 4.9.0
+	 * @version 5.3.8
 	 * @since   2.5.3
 	 * @todo    (maybe) `template_redirect` instead of `wp`
 	 */
@@ -58,6 +58,10 @@ class WCJ_Order_Min_Amount extends WCJ_Module {
 		if ( $is_order_minimum_amount_enabled ) {
 			add_action( 'woocommerce_checkout_process', array( $this, 'order_minimum_amount' ) );
 			add_action( 'woocommerce_before_cart',      array( $this, 'order_minimum_amount' ) );
+			if( wcj_is_plugin_activated( 'woo-gutenberg-products-block', 'woocommerce-gutenberg-products-block.php' ) ){
+				// For the Woocommerce blocks plugin
+				add_action( 'wooocommerce_store_api_validate_cart_item',      array( $this, 'order_minimum_amount' ) );
+			}	
 			if ( 'yes' === wcj_get_option( 'wcj_order_minimum_amount_stop_from_seeing_checkout', 'no' ) ) {
 				add_action( 'wp', array( $this, 'stop_from_seeing_checkout' ), 100 );
 			}

--- a/includes/class-wcj-order-numbers.php
+++ b/includes/class-wcj-order-numbers.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Order Numbers
  *
- * @version 5.2.0
+ * @version 5.3.8
  * @author  Pluggabl LLC.
  */
 
@@ -204,6 +204,15 @@ class WCJ_Order_Numbers extends WCJ_Module {
 		$search_no_suffix_and_prefix = preg_replace( "/{$suffix}\z/i", '', $search_no_suffix );
 		$final_search                = empty( $search_no_suffix_and_prefix ) ? $search : $search_no_suffix_and_prefix;
 
+		if($search == $final_search){
+
+			$final_search = substr($final_search,strlen( $prefix ));
+			$final_search = ltrim($final_search,0);
+			if(strlen( $suffix ) > 0)
+			{
+				$final_search = substr($final_search,0,-strlen( $suffix ));
+			}
+		}
 		// Post Status
 		$post_status = isset( $_GET['post_status'] ) ? $_GET['post_status'] : 'any';
 

--- a/includes/class-wcj-payment-gateways-currency.php
+++ b/includes/class-wcj-payment-gateways-currency.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Gateways Currency Converter
  *
- * @version 5.3.6
+ * @version 5.3.8
  * @since   2.3.0
  * @author  Pluggabl LLC.
  */
@@ -136,7 +136,7 @@ class WCJ_Payment_Gateways_Currency extends WCJ_Module {
 	/**
 	 * change_price_by_gateway.
 	 *
-	 * @version 4.3.0
+	 * @version 5.3.8
 	 * @since   2.3.0
 	 */
 	function change_price_by_gateway( $price, $product ) {
@@ -145,7 +145,9 @@ class WCJ_Payment_Gateways_Currency extends WCJ_Module {
 			if ( '' != $current_gateway ) {
 				$gateway_currency_exchange_rate = wcj_get_option( 'wcj_gateways_currency_exchange_rate_' . $current_gateway );
 				$gateway_currency_exchange_rate = str_replace( ',', '.', $gateway_currency_exchange_rate );
-				$price                          = $price * $gateway_currency_exchange_rate;
+				if(is_numeric($price)){
+					$price                          = $price * $gateway_currency_exchange_rate;
+				}	
 			}
 		}
 		return $price;

--- a/includes/class-wcj-product-by-date.php
+++ b/includes/class-wcj-product-by-date.php
@@ -52,6 +52,9 @@ class WCJ_Product_By_Date extends WCJ_Module {
 					add_filter( 'woocommerce_is_purchasable', array( $this, 'check_is_purchasable_by_date' ), PHP_INT_MAX, 2 );
 				}
 				add_action( 'woocommerce_single_product_summary', array( $this, 'maybe_add_unavailable_by_date_message' ), 30 );
+				if('yes' === wcj_get_option( 'wcj_product_by_date_show_message_on_shop_enabled', 'no' )){
+					add_action( 'woocommerce_shop_loop_item_title', array( $this, 'maybe_add_unavailable_by_date_message' ), 30 );
+				}	
 			}
 		}
 	}

--- a/includes/functions/wcj-functions-products.php
+++ b/includes/functions/wcj-functions-products.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Functions - Products
  *
- * @version 5.3.6
+ * @version 5.3.8
  * @since   2.9.0
  * @author  Pluggabl LLC.
  */
@@ -151,7 +151,7 @@ if ( ! function_exists( 'wcj_get_product_display_price' ) ) {
 	/**
 	 * wcj_get_product_display_price.
 	 *
-	 * @version 3.8.0
+	 * @version 5.3.8
 	 * @since   2.7.0
 	 * @todo    `$scope` in `WCJ_IS_WC_VERSION_BELOW_3` (i.e. `cart`)
 	 */
@@ -163,9 +163,9 @@ if ( ! function_exists( 'wcj_get_product_display_price' ) ) {
 			return $_product->get_display_price( $price, $qty );
 		} else {
 			$minus_sign = '';
-			if ( $price < 0 ) {
-				$minus_sign = '-';
-				$price *= -1;
+			if ( $price < 0  && is_numeric($price) ) {
+					$minus_sign = '-';
+					$price *= -1;
 			}
 			if ( 'cart' === $scope ) {
 				$display_price = ( 'incl' === wcj_get_option( 'woocommerce_tax_display_cart' ) ?

--- a/includes/settings/wcj-settings-product-by-date.php
+++ b/includes/settings/wcj-settings-product-by-date.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Settings - Product Availability by Date
  *
- * @version 4.7.0
+ * @version 5.3.8
  * @since   2.9.1
  * @author  Pluggabl LLC.
  */
@@ -117,6 +117,14 @@ $settings = array_merge( $settings, array(
 		'title'    => __( 'Advanced Options', 'woocommerce-jetpack' ),
 		'type'     => 'title',
 		'id'       => 'wcj_product_by_date_advanced_options',
+	),
+	array(
+		'title'    => __( 'Show Message on Category/shop Page', 'woocommerce-jetpack' ),
+		'desc'     => '<strong>' . __( 'Show Message on shop Page', 'woocommerce-jetpack' ) . '</strong>',
+		'desc_tip' => __( 'Enable this if you also want to show message on shop page.', 'woocommerce-jetpack' ),
+		'id'       => 'wcj_product_by_date_show_message_on_shop_enabled',
+		'default'  => 'no',
+		'type'     => 'checkbox',
 	),
 	array(
 		'title'    => __( 'Action', 'woocommerce-jetpack' ),

--- a/includes/shortcodes/class-wcj-shortcodes-products.php
+++ b/includes/shortcodes/class-wcj-shortcodes-products.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Shortcodes - Products
  *
- * @version 5.3.7
+ * @version 5.3.8
  * @author  Pluggabl LLC.
  */
 
@@ -15,7 +15,7 @@ class WCJ_Products_Shortcodes extends WCJ_Shortcodes {
 	/**
 	 * Constructor.
 	 *
-	 * @version 3.6.0
+	 * @version 3.6.1
 	 * @todo    (maybe) add `[wcj_product_stock_price]`
 	 */
 	function __construct() {
@@ -78,6 +78,9 @@ class WCJ_Products_Shortcodes extends WCJ_Shortcodes {
 			'image_nr'              => 1,
 			'multiply_by'           => '',
 			'multiply_by_meta'      => '',
+			'addition_by'			=>'',
+			'subtraction_by'		=>'',
+			'division_by'		    =>'',
 			'hide_currency'         => 'no',
 			'excerpt_length'        => 0, // deprecated
 			'length'                => 0,
@@ -386,7 +389,7 @@ class WCJ_Products_Shortcodes extends WCJ_Shortcodes {
 	/**
 	 * get_product_price_including_or_excluding_tax.
 	 *
-	 * @version 2.7.0
+	 * @version 2.7.1
 	 * @since   2.5.7
 	 */
 	function get_product_price_including_or_excluding_tax( $atts, $including_or_excluding ) {
@@ -410,6 +413,23 @@ class WCJ_Products_Shortcodes extends WCJ_Shortcodes {
 					$min = $min * $atts['multiply_by'];
 					$max = $max * $atts['multiply_by'];
 				}
+				// For Additon
+				if ( 0 != $atts['addition_by'] && is_numeric( $atts['addition_by'] ) ) {
+					$min = $min + $atts['addition_by'];
+					$max = $max + $atts['addition_by'];
+				}
+				
+				//For Subsaction
+				if ( 0 != $atts['subtraction_by'] && is_numeric( $atts['subtraction_by'] ) ) {
+					$min = $min - $atts['subtraction_by'];
+					$max = $max - $atts['subtraction_by'];
+				}
+
+				//For Division
+				if ( 0 != $atts['division_by'] && is_numeric( $atts['division_by'] ) ) {
+					$min = $min / $atts['division_by'];
+					$max = $max / $atts['division_by'];
+				}	
 				if ( 'yes' !== $atts['hide_currency'] ) {
 					$min = wc_price( $min );
 					$max = wc_price( $max );
@@ -425,6 +445,15 @@ class WCJ_Products_Shortcodes extends WCJ_Shortcodes {
 			}
 			if ( 0 != $atts['multiply_by'] && is_numeric( $atts['multiply_by'] ) ) {
 				$the_price = $the_price * $atts['multiply_by'];
+			}
+			if ( 0 != $atts['addition_by'] && is_numeric( $atts['addition_by'] ) ) {
+				$the_price = $the_price + $atts['addition_by'];
+			}	
+			if ( 0 != $atts['subtraction_by'] && is_numeric( $atts['subtraction_by'] ) ) {
+				$the_price = $the_price - $atts['subtraction_by'];
+			}
+			if ( 0 != $atts['division_by'] && is_numeric( $atts['division_by'] ) ) {
+				$the_price = $the_price / $atts['division_by'];
 			}
 			return ( 'yes' === $atts['hide_currency'] ) ? $the_price : wc_price( $the_price );
 		}
@@ -630,13 +659,13 @@ class WCJ_Products_Shortcodes extends WCJ_Shortcodes {
 	/**
 	 * wcj_product_total_sales.
 	 *
-	 * @version 2.7.0
+	 * @version 5.3.8
 	 * @since   2.2.6
 	 */
 	function wcj_product_total_sales( $atts ) {
 		$product_custom_fields = get_post_custom( wcj_get_product_id_or_variation_parent_id( $this->the_product ) );
 		$total_sales = ( isset( $product_custom_fields['total_sales'][0] ) ) ? $product_custom_fields['total_sales'][0] : '';
-		if ( 0 != $atts['offset'] ) {
+		if ( 0 != $atts['offset'] && !is_numeric($total_sales) ) {
 			$total_sales += $atts['offset'];
 		}
 		return ( 0 == $total_sales && 'yes' === $atts['hide_if_zero'] ) ? '' : $total_sales;

--- a/langs/woocommerce-jetpack.pot
+++ b/langs/woocommerce-jetpack.pot
@@ -193,7 +193,7 @@ msgid "Export all Booster's options to a file."
 msgstr ""
 
 #: includes/admin/class-wc-settings-jetpack.php:473
-#: includes/class-wcj-purchase-data.php:97
+#: includes/class-wcj-purchase-data.php:94
 msgid "Import"
 msgstr ""
 
@@ -699,7 +699,7 @@ msgstr ""
 #: includes/class-wcj-admin-bar.php:440
 #: includes/settings/wcj-settings-offer-price.php:49
 #: includes/settings/wcj-settings-stock.php:101
-#: includes/shortcodes/class-wcj-shortcodes-products.php:593
+#: includes/shortcodes/class-wcj-shortcodes-products.php:594
 msgid "Out of stock"
 msgstr ""
 
@@ -1043,17 +1043,17 @@ msgstr ""
 msgid "Add custom info to the cart page."
 msgstr ""
 
-#: includes/class-wcj-checkout-core-fields.php:27
+#: includes/class-wcj-checkout-core-fields.php:25
 msgid "Checkout Core Fields"
 msgstr ""
 
-#: includes/class-wcj-checkout-core-fields.php:28
+#: includes/class-wcj-checkout-core-fields.php:26
 msgid ""
 "Customize core checkout fields. Disable/enable fields, set required, change "
 "labels and/or placeholders; Setup fields by category (Plus)"
 msgstr ""
 
-#: includes/class-wcj-checkout-core-fields.php:29
+#: includes/class-wcj-checkout-core-fields.php:27
 msgid ""
 "Customize core checkout fields. Disable/enable fields, set required, change "
 "labels and/or placeholders etc."
@@ -2400,7 +2400,7 @@ msgstr ""
 #: includes/class-wcj-my-account.php:496
 #: includes/class-wcj-product-bulk-meta-editor.php:280
 #: includes/class-wcj-product-by-user.php:207
-#: includes/class-wcj-purchase-data.php:98
+#: includes/class-wcj-purchase-data.php:95
 #: includes/class-wcj-track-users.php:335
 #: includes/classes/class-wcj-module.php:891
 #: includes/functions/wcj-functions-general.php:189
@@ -2741,23 +2741,23 @@ msgstr ""
 msgid "Tool renumerates all orders."
 msgstr ""
 
-#: includes/class-wcj-order-numbers.php:317
+#: includes/class-wcj-order-numbers.php:326
 msgid "Orders successfully renumerated!"
 msgstr ""
 
-#: includes/class-wcj-order-numbers.php:320
+#: includes/class-wcj-order-numbers.php:329
 #, php-format
 msgid "Sequential number generation is enabled. Next order number will be %s."
 msgstr ""
 
-#: includes/class-wcj-order-numbers.php:329
+#: includes/class-wcj-order-numbers.php:338
 #, php-format
 msgid ""
 "Press the button below to renumerate all existing orders starting from order "
 "counter settings in <a href=\"%s\">Order Numbers</a> module."
 msgstr ""
 
-#: includes/class-wcj-order-numbers.php:336
+#: includes/class-wcj-order-numbers.php:345
 msgid "Renumerate orders"
 msgstr ""
 
@@ -3726,7 +3726,7 @@ msgid "Save"
 msgstr ""
 
 #: includes/class-wcj-product-bulk-meta-editor.php:390
-#: includes/class-wcj-purchase-data.php:81
+#: includes/class-wcj-purchase-data.php:78
 #: includes/export/class-wcj-fields-helper.php:280
 #: includes/functions/wcj-functions-reports.php:24
 #: includes/settings/wcj-settings-product-bulk-meta-editor.php:42
@@ -3805,7 +3805,7 @@ msgid "Products category"
 msgstr ""
 
 #: includes/class-wcj-product-bulk-price-converter.php:262
-#: includes/shortcodes/class-wcj-shortcodes-products.php:369
+#: includes/shortcodes/class-wcj-shortcodes-products.php:357
 msgid "Any"
 msgstr ""
 
@@ -3950,19 +3950,19 @@ msgstr ""
 msgid "Set product availability by date."
 msgstr ""
 
-#: includes/class-wcj-product-by-date.php:111
+#: includes/class-wcj-product-by-date.php:114
 #: includes/settings/wcj-settings-product-by-date.php:107
 msgid "%product_title% is not available until %direct_date%."
 msgstr ""
 
-#: includes/class-wcj-product-by-date.php:118
-#: includes/class-wcj-product-by-date.php:120
+#: includes/class-wcj-product-by-date.php:121
+#: includes/class-wcj-product-by-date.php:123
 #: includes/settings/wcj-settings-product-by-date.php:95
 msgid "<p style=\"color:red;\">%product_title% is not available this month.</p>"
 msgstr ""
 
-#: includes/class-wcj-product-by-date.php:121
-#: includes/class-wcj-product-by-date.php:123
+#: includes/class-wcj-product-by-date.php:124
+#: includes/class-wcj-product-by-date.php:126
 #: includes/settings/wcj-settings-product-by-date.php:83
 msgid ""
 "<p style=\"color:red;\">%product_title% is available only on %date_this_month"
@@ -4435,7 +4435,6 @@ msgid ""
 msgstr ""
 
 #: includes/class-wcj-product-price-by-formula.php:241
-#: includes/class-wcj-purchase-data.php:256
 msgid "Error in formula"
 msgstr ""
 
@@ -4668,41 +4667,41 @@ msgstr ""
 msgid "Products XML file #%s created successfully."
 msgstr ""
 
-#: includes/class-wcj-purchase-data.php:30
+#: includes/class-wcj-purchase-data.php:28
 msgid "Cost of Goods"
 msgstr ""
 
-#: includes/class-wcj-purchase-data.php:31
+#: includes/class-wcj-purchase-data.php:29
 msgid ""
 "Save product purchase costs data for admin reports (1 custom field allowed in "
 "free version)."
 msgstr ""
 
-#: includes/class-wcj-purchase-data.php:32
+#: includes/class-wcj-purchase-data.php:30
 msgid "Save product purchase costs data for admin reports."
 msgstr ""
 
-#: includes/class-wcj-purchase-data.php:38
+#: includes/class-wcj-purchase-data.php:36
 msgid "\"WooCommerce Cost of Goods\" Data Import"
 msgstr ""
 
-#: includes/class-wcj-purchase-data.php:39
+#: includes/class-wcj-purchase-data.php:37
 msgid "Import products costs from \"WooCommerce Cost of Goods\"."
 msgstr ""
 
-#: includes/class-wcj-purchase-data.php:82
+#: includes/class-wcj-purchase-data.php:79
 msgid "Product Title"
 msgstr ""
 
-#: includes/class-wcj-purchase-data.php:83
+#: includes/class-wcj-purchase-data.php:80
 msgid "WooCommerce Cost of Goods (source)"
 msgstr ""
 
-#: includes/class-wcj-purchase-data.php:84
+#: includes/class-wcj-purchase-data.php:81
 msgid "Booster: Product cost (destination)"
 msgstr ""
 
-#: includes/class-wcj-purchase-data.php:120
+#: includes/class-wcj-purchase-data.php:116
 #: includes/shipping/class-wc-shipping-wcj-custom-with-shipping-zones.php:139
 #: includes/shipping/class-wc-shipping-wcj-custom-with-shipping-zones.php:209
 #: includes/shipping/class-wc-shipping-wcj-custom.php:122
@@ -4710,30 +4709,30 @@ msgstr ""
 msgid "Cost"
 msgstr ""
 
-#: includes/class-wcj-purchase-data.php:123
-#: includes/class-wcj-purchase-data.php:188
-#: includes/class-wcj-purchase-data.php:455
+#: includes/class-wcj-purchase-data.php:119
+#: includes/class-wcj-purchase-data.php:182
+#: includes/class-wcj-purchase-data.php:269
 #: includes/functions/wcj-functions-reports.php:28
 #: includes/settings/wcj-settings-purchase-data.php:144
 #: includes/settings/wcj-settings-purchase-data.php:172
 msgid "Profit"
 msgstr ""
 
-#: includes/class-wcj-purchase-data.php:191
+#: includes/class-wcj-purchase-data.php:185
 #: includes/settings/wcj-settings-purchase-data.php:153
 #: includes/settings/wcj-settings-purchase-data.php:179
 msgid "Purchase Cost"
 msgstr ""
 
-#: includes/class-wcj-purchase-data.php:453
+#: includes/class-wcj-purchase-data.php:267
 msgid "Selling"
 msgstr ""
 
-#: includes/class-wcj-purchase-data.php:454
+#: includes/class-wcj-purchase-data.php:268
 msgid "Buying"
 msgstr ""
 
-#: includes/class-wcj-purchase-data.php:462
+#: includes/class-wcj-purchase-data.php:276
 msgid "Report"
 msgstr ""
 
@@ -16850,18 +16849,30 @@ msgid "Message when product is not available by direct date."
 msgstr ""
 
 #: includes/settings/wcj-settings-product-by-date.php:122
-msgid "Action"
+msgid "Show Message on Category/shop Page"
 msgstr ""
 
 #: includes/settings/wcj-settings-product-by-date.php:123
+msgid "Show Message on shop Page"
+msgstr ""
+
+#: includes/settings/wcj-settings-product-by-date.php:124
+msgid "Enable this if you also want to show message on shop page."
+msgstr ""
+
+#: includes/settings/wcj-settings-product-by-date.php:130
+msgid "Action"
+msgstr ""
+
+#: includes/settings/wcj-settings-product-by-date.php:131
 msgid "Action to be taken, when product is not available by date."
 msgstr ""
 
-#: includes/settings/wcj-settings-product-by-date.php:128
+#: includes/settings/wcj-settings-product-by-date.php:136
 msgid "Make product non-purchasable"
 msgstr ""
 
-#: includes/settings/wcj-settings-product-by-date.php:129
+#: includes/settings/wcj-settings-product-by-date.php:137
 msgid "Only output message"
 msgstr ""
 
@@ -20066,7 +20077,7 @@ msgstr ""
 msgid "Attribute \"name\" is required!"
 msgstr ""
 
-#: includes/shortcodes/class-wcj-shortcodes-orders.php:348
+#: includes/shortcodes/class-wcj-shortcodes-orders.php:339
 #, php-format
 msgid "Refund #%1$s - %2$s"
 msgstr ""
@@ -20109,20 +20120,20 @@ msgstr ""
 msgid "Edit Product"
 msgstr ""
 
-#: includes/shortcodes/class-wcj-shortcodes-products.php:342
+#: includes/shortcodes/class-wcj-shortcodes-products.php:331
 #, php-format
 msgid "%s ago"
 msgstr ""
 
-#: includes/shortcodes/class-wcj-shortcodes-products.php:349
+#: includes/shortcodes/class-wcj-shortcodes-products.php:338
 msgid "No sales yet."
 msgstr ""
 
-#: includes/shortcodes/class-wcj-shortcodes-products.php:590
+#: includes/shortcodes/class-wcj-shortcodes-products.php:591
 msgid "In stock"
 msgstr ""
 
-#: includes/shortcodes/class-wcj-shortcodes-products.php:1020
+#: includes/shortcodes/class-wcj-shortcodes-products.php:1009
 msgid "from %level_min_qty% pcs."
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -203,7 +203,7 @@ You can see the differences between versions in this [table](https://booster.io/
 * Dev - SHIPPING & ORDERS - Order Minimum Amount - Compatibility issue has been resolved with Woocommerce Blocks plugin
 * Fix - SHIPPING & ORDERS - Order Numbers - Custom order number search is not working when date parameter is set
 * Dev - PDF INVOICING & PACKING SLIPS - Add addition, subtraction, division attributes to shortcodes like multiply_by
-* Dev - PRODUCTS - Shortcodes - Exclude Item_total from order total and order subtotal if product has been excluded by tag, category or attributes name in invoice pdf.
+* Dev - PRODUCTS - Shortcodes - Exclude Item_total from order total and order subtotal if product has been excluded by tag, category or attribute name in invoice pdf.
 
 = 5.3.7 - 28/01/2021 =
 * Fix - CART & CHECKOUT - Checkout Core Fields - Fix "Checkout Field arragement not working" issue.

--- a/readme.txt
+++ b/readme.txt
@@ -197,13 +197,13 @@ You can see the differences between versions in this [table](https://booster.io/
 
 * PHP 8.0.2 tested
 * WooCommerce 5.0 tested
-* Dev - PRODUCTS - Stock - For Variable product, custom stock message should be shown before option selection, if stock management is set at product level.
+* Dev - PRODUCTS - Stock - For a Variable product, the custom stock message should be shown before option selection, if stock management is set at the product level.
 * Dev - PRODUCTS - Stock - Show product availability message on shop/loop/search etc.
 * Fix - PRICES & CURRENCIES - Global Discount - Discount conflict when we enable global and wholesale both discounts.
 * Dev - SHIPPING & ORDERS - Order Minimum Amount - Compatibility issue has been resolved with Woocommerce Blocks plugin
-* Fix - SHIPPING & ORDERS - Order Numbers - Custom order number search is not working when date parameter is set
+* Fix - SHIPPING & ORDERS - Order Numbers - Custom order number search is not working when the date parameter is set
 * Dev - PDF INVOICING & PACKING SLIPS - Add addition, subtraction, division attributes to shortcodes like multiply_by
-* Dev - PRODUCTS - Shortcodes - Exclude Item_total from order total and order subtotal if product has been excluded by tag, category or attribute name in invoice pdf.
+* Dev - PRODUCTS - Shortcodes - Exclude Item_total from order total and order subtotal if the product has been excluded by tag, category or attribute name in invoice pdf.
 
 = 5.3.7 - 28/01/2021 =
 * Fix - CART & CHECKOUT - Checkout Core Fields - Fix "Checkout Field arragement not working" issue.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: anbinder, karzin, pluggabl
 Tags: woocommerce, booster for woocommerce, woocommerce jetpack
 Requires at least: 4.4
 Tested up to: 5.6
-Stable tag: 5.3.7
+Stable tag: 5.3.8
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -193,11 +193,24 @@ You can see the differences between versions in this [table](https://booster.io/
 
 == Changelog ==
 
+= 5.3.8 - 24/02/2021 =
+
+* PHP 8.0.2 tested
+* WooCommerce 5.0 tested
+* Dev - PRODUCTS - Stock - For Variable product, custom stock message should be shown before option selection, if stock management is set at product level.
+* Dev - PRODUCTS - Stock - Show product availability message on shop/loop/search etc.
+* Fix - PRICES & CURRENCIES - Global Discount - Discount conflict when we enable global and wholesale both discounts.
+* Dev - SHIPPING & ORDERS - Order Minimum Amount - Compatibility issue has been resolved with Woocommerce Blocks plugin
+* Fix - SHIPPING & ORDERS - Order Numbers - Custom order number search is not working when date parameter is set
+* Dev - PDF INVOICING & PACKING SLIPS - Add addition, subtraction, division attributes to shortcodes like multiply_by
+* Dev - PRODUCTS - Shortcodes - Exclude Item_total from order total and order subtotal if product has been excluded by tag, category or attributes name in invoice pdf.
+
 = 5.3.7 - 28/01/2021 =
 * Fix - CART & CHECKOUT - Checkout Core Fields - Fix "Checkout Field arragement not working" issue.
 * Fix - PRICES & CURRENCIES - Currency Exchange Rates - Fix "Woocommerce store base currency Exchange rate" issue.
 * Dev - EMAILS & MISC. - Export - Added feature to export new column for 'allowed_user_roles' and 'not_allowed_user_roles'.
 * Fix - PDF INVOICING & PACKING SLIPS - PDF Invoicing - Fix "Order total after refund" shortcode with new attribute.
+* Fix - PRODUCTS - Cost of Goods - Fix "Profit" amount to consider "Wholesale discount","product price by formula" and also made it compatible with multi-currency.
 * Fix - CART & CHECKOUT - EU VAT Number - Fix "EU VAT Number" should be required for EU countries only.
 
 = 5.3.6 - 30/12/2020 =

--- a/woocommerce-jetpack.php
+++ b/woocommerce-jetpack.php
@@ -3,7 +3,7 @@
 Plugin Name: Booster for WooCommerce
 Plugin URI: https://booster.io
 Description: Supercharge your WooCommerce site with these awesome powerful features. More than 100 modules. All in one WooCommerce plugin.
-Version: 5.3.7
+Version: 5.3.8
 Author: Pluggabl LLC
 Author URI: https://booster.io
 Text Domain: woocommerce-jetpack
@@ -57,7 +57,7 @@ final class WC_Jetpack {
 	 * @var   string
 	 * @since 2.4.7
 	 */
-	public $version = '5.3.7';
+	public $version = '5.3.8';
 
 	/**
 	 * @var WC_Jetpack The single instance of the class


### PR DESCRIPTION
= 5.3.8 - 24/02/2021 =

* PHP 8.0.2 tested
* WooCommerce 5.0 tested
* Dev - PRODUCTS - Stock - For a Variable product, the custom stock message should be shown before option selection, if stock management is set at the product level.
* Dev - PRODUCTS - Stock - Show product availability message on shop/loop/search etc.
* Fix - PRICES & CURRENCIES - Global Discount - Discount conflict when we enable global and wholesale both discounts.
* Dev - SHIPPING & ORDERS - Order Minimum Amount - Compatibility issue has been resolved with Woocommerce Blocks plugin
* Fix - SHIPPING & ORDERS - Order Numbers - Custom order number search is not working when the date parameter is set
* Dev - PDF INVOICING & PACKING SLIPS - Add addition, subtraction, division attributes to shortcodes like multiply_by
* Dev - PRODUCTS - Shortcodes - Exclude Item_total from order total and order subtotal if the product has been excluded by tag, category or attribute name in invoice pdf.