### PR TITLE
v5.6.3

### DIFF
--- a/includes/class-wcj-checkout-files-upload.php
+++ b/includes/class-wcj-checkout-files-upload.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Checkout Files Upload
  *
- * @version 5.6.3-dev
+ * @version 5.6.3
  * @since   2.4.5
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -834,7 +834,7 @@ if ( ! class_exists( 'WCJ_Checkout_Files_Upload' ) ) :
 		/**
 		 * Maybe_get_image.
 		 *
-		 * @version 5.6.3-dev
+		 * @version 5.6.3
 		 * @since   3.7.0
 		 * @param string $link defines the link.
 		 * @param int    $i defines the value of i.

--- a/includes/class-wcj-free-price.php
+++ b/includes/class-wcj-free-price.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Free Price
  *
- * @version 5.2.0
+ * @version 5.6.3-dev
  * @since   2.5.9
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -87,14 +87,14 @@ if ( ! class_exists( 'WCJ_Free_Price' ) ) :
 		/**
 		 * Maybe_modify_price
 		 *
-		 * @version 2.7.0
+		 * @version 5.6.3-dev
 		 * @since   2.7.0
 		 * @param int            $price defines the price.
 		 * @param string | array $_product defines the _product.
 		 */
 		public function maybe_modify_price( $price, $_product ) {
 			if ( '' !== $price ) {
-				if ( 0 === $_product->get_price() ) {
+				if ( '0' === $_product->get_price() ) {
 					if ( $_product->is_type( 'grouped' ) ) {
 						return ( $this->are_all_prices_free( $_product, 'grouped' ) ) ? $this->modify_free_price_grouped( $price, $_product ) : $price;
 					} elseif ( $_product->is_type( 'variable' ) ) {

--- a/includes/class-wcj-free-price.php
+++ b/includes/class-wcj-free-price.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Free Price
  *
- * @version 5.6.3-dev
+ * @version 5.6.3
  * @since   2.5.9
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -87,7 +87,7 @@ if ( ! class_exists( 'WCJ_Free_Price' ) ) :
 		/**
 		 * Maybe_modify_price
 		 *
-		 * @version 5.6.3-dev
+		 * @version 5.6.3
 		 * @since   2.7.0
 		 * @param int            $price defines the price.
 		 * @param string | array $_product defines the _product.

--- a/includes/class-wcj-mini-cart.php
+++ b/includes/class-wcj-mini-cart.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Mini Cart Custom Info
  *
- * @version 5.6.3-dev
+ * @version 5.6.3
  * @since   2.2.0
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -47,7 +47,7 @@ if ( ! class_exists( 'WCJ_Mini_Cart' ) ) :
 		/**
 		 * Add_mini_cart_custom_info.
 		 *
-		 * @version 5.6.3-dev
+		 * @version 5.6.3
 		 */
 		public function add_mini_cart_custom_info() {
 			$current_filter          = current_filter();

--- a/includes/class-wcj-mini-cart.php
+++ b/includes/class-wcj-mini-cart.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Mini Cart Custom Info
  *
- * @version 5.2.0
+ * @version 5.6.3-dev
  * @since   2.2.0
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -47,7 +47,7 @@ if ( ! class_exists( 'WCJ_Mini_Cart' ) ) :
 		/**
 		 * Add_mini_cart_custom_info.
 		 *
-		 * @version 2.4.6
+		 * @version 5.6.3-dev
 		 */
 		public function add_mini_cart_custom_info() {
 			$current_filter          = current_filter();
@@ -57,7 +57,7 @@ if ( ! class_exists( 'WCJ_Mini_Cart' ) ) :
 				if (
 				'' !== wcj_get_option( 'wcj_mini_cart_custom_info_content_' . $i ) &&
 				wcj_get_option( 'wcj_mini_cart_custom_info_hook_' . $i, 'woocommerce_after_mini_cart' ) === $current_filter &&
-				wcj_get_option( 'wcj_mini_cart_custom_info_priority_' . $i, 10 ) === $current_filter_priority
+				wcj_get_option( 'wcj_mini_cart_custom_info_priority_' . $i, 10 ) === (string) $current_filter_priority
 				) {
 					echo do_shortcode( wcj_get_option( 'wcj_mini_cart_custom_info_content_' . $i ) );
 				}

--- a/includes/class-wcj-my-account.php
+++ b/includes/class-wcj-my-account.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - My Account
  *
- * @version 5.6.2
+ * @version 5.6.3-dev
  * @since   2.9.0
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -560,13 +560,15 @@ if ( ! class_exists( 'WCJ_My_Account' ) ) :
 		/**
 		 * Process_woocommerce_mark_order_status.
 		 *
-		 * @version 5.6.2
+		 * @version 5.6.3-dev
 		 * @since   2.9.0
 		 */
 		public function process_woocommerce_mark_order_status() {
+			$statuses_to_allow = wcj_get_option( 'wcj_my_account_add_order_status_actions', '' );
 			if (
 				isset( $_GET['wcj_action'] ) && 'wcj_woocommerce_mark_order_status' === $_GET['wcj_action'] &&
 				isset( $_GET['status'] ) &&
+				in_array( $_GET['status'], $statuses_to_allow, true ) &&
 				isset( $_GET['order_id'] ) &&
 				isset( $_GET['_wpnonce'] )
 			) {

--- a/includes/class-wcj-my-account.php
+++ b/includes/class-wcj-my-account.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - My Account
  *
- * @version 5.6.3-dev
+ * @version 5.6.3
  * @since   2.9.0
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -560,7 +560,7 @@ if ( ! class_exists( 'WCJ_My_Account' ) ) :
 		/**
 		 * Process_woocommerce_mark_order_status.
 		 *
-		 * @version 5.6.3-dev
+		 * @version 5.6.3
 		 * @since   2.9.0
 		 */
 		public function process_woocommerce_mark_order_status() {

--- a/includes/class-wcj-order-custom-statuses.php
+++ b/includes/class-wcj-order-custom-statuses.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Order Custom Statuses
  *
- * @version 5.6.2
+ * @version 5.6.3-dev
  * @since   2.2.0
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -463,7 +463,7 @@ if ( ! class_exists( 'WCJ_Order_Custom_Statuses' ) ) :
 		 *
 		 * Using Javascript until WordPress core fixes: http://core.trac.wordpress.org/ticket/16031
 		 *
-		 * @version 5.6.2
+		 * @version 5.6.3-dev
 		 * @since   2.2.7
 		 */
 		public function bulk_admin_footer() {
@@ -477,18 +477,8 @@ if ( ! class_exists( 'WCJ_Order_Custom_Statuses' ) ) :
 					}
 					?>
 				jQuery(function() {
-					jQuery('<option>').val('mark_<?php echo wp_kses_post( $key ); ?>').text('
-															<?php
-															echo wp_kses_post( 'Mark', 'woocommerce-jetpack' ) . ' ' .
-															wp_kses_post( $order_status );
-															?>
-						').appendTo('select[name="action"]');
-					jQuery('<option>').val('mark_<?php echo wp_kses_post( $key ); ?>').text('
-															<?php
-															echo wp_kses_post( 'Mark', 'woocommerce-jetpack' ) . ' ' .
-															wp_kses_post( $order_status );
-															?>
-						').appendTo('select[name="action2"]');
+					jQuery('<option>').val('mark_<?php echo wp_kses_post( $key ); ?>').text('<?php echo wp_kses_post( 'Mark', 'woocommerce-jetpack' ) . ' ' . wp_kses_post( $order_status ); ?>').appendTo('select[name="action"]');
+					jQuery('<option>').val('mark_<?php echo wp_kses_post( $key ); ?>').text('<?php echo wp_kses_post( 'Mark', 'woocommerce-jetpack' ) . ' ' . wp_kses_post( $order_status ); ?>').appendTo('select[name="action2"]');
 				});
 								<?php
 				}

--- a/includes/class-wcj-order-custom-statuses.php
+++ b/includes/class-wcj-order-custom-statuses.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Order Custom Statuses
  *
- * @version 5.6.3-dev
+ * @version 5.6.3
  * @since   2.2.0
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -463,7 +463,7 @@ if ( ! class_exists( 'WCJ_Order_Custom_Statuses' ) ) :
 		 *
 		 * Using Javascript until WordPress core fixes: http://core.trac.wordpress.org/ticket/16031
 		 *
-		 * @version 5.6.3-dev
+		 * @version 5.6.3
 		 * @since   2.2.7
 		 */
 		public function bulk_admin_footer() {

--- a/includes/class-wcj-price-by-user-role.php
+++ b/includes/class-wcj-price-by-user-role.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Price based on User Role
  *
- * @version 5.6.3-dev
+ * @version 5.6.3
  * @since   2.5.0
  * @author  Pluggabl LLC.
  * @todo    Fix "Make Empty Price" option for variable products
@@ -228,7 +228,7 @@ if ( ! class_exists( 'WCJ_Price_By_User_Role' ) ) :
 		/**
 		 * Add_notice_query_var.
 		 *
-		 * @version 5.6.3-dev
+		 * @version 5.6.3
 		 * @since   2.5.0
 		 * @param string $location defines the location.
 		 */

--- a/includes/class-wcj-price-by-user-role.php
+++ b/includes/class-wcj-price-by-user-role.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Price based on User Role
  *
- * @version 5.6.2
+ * @version 5.6.3-dev
  * @since   2.5.0
  * @author  Pluggabl LLC.
  * @todo    Fix "Make Empty Price" option for variable products
@@ -228,13 +228,13 @@ if ( ! class_exists( 'WCJ_Price_By_User_Role' ) ) :
 		/**
 		 * Add_notice_query_var.
 		 *
-		 * @version 5.5.9
+		 * @version 5.6.3-dev
 		 * @since   2.5.0
 		 * @param string $location defines the location.
 		 */
 		public function add_notice_query_var( $location ) {
 			remove_filter( 'redirect_post_location', array( $this, 'add_notice_query_var' ), 99 );
-			return add_query_arg( array( 'wcj_product_price_by_user_role_admin_notice' => true ), $location );
+			return esc_url_raw( add_query_arg( array( 'wcj_product_price_by_user_role_admin_notice' => true ), $location ) );
 		}
 
 		/**

--- a/includes/class-wcj-product-bookings.php
+++ b/includes/class-wcj-product-bookings.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Bookings
  *
- * @version 5.6.2
+ * @version 5.6.3-dev
  * @since   2.5.0
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -511,13 +511,13 @@ if ( ! class_exists( 'WCJ_Product_Bookings' ) ) :
 		/**
 		 * Add_notice_query_var.
 		 *
-		 * @version 5.5.9
+		 * @version 5.6.3-dev
 		 * @since   2.5.0
 		 * @param string $location defines the location.
 		 */
 		public function add_notice_query_var( $location ) {
 			remove_filter( 'redirect_post_location', array( $this, 'add_notice_query_var' ), 99 );
-			return add_query_arg( array( 'wcj_product_bookings_admin_notice' => true ), $location );
+			return esc_url_raw( add_query_arg( array( 'wcj_product_bookings_admin_notice' => true ), $location ) );
 		}
 
 		/**

--- a/includes/class-wcj-product-bookings.php
+++ b/includes/class-wcj-product-bookings.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Bookings
  *
- * @version 5.6.3-dev
+ * @version 5.6.3
  * @since   2.5.0
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -511,7 +511,7 @@ if ( ! class_exists( 'WCJ_Product_Bookings' ) ) :
 		/**
 		 * Add_notice_query_var.
 		 *
-		 * @version 5.6.3-dev
+		 * @version 5.6.3
 		 * @since   2.5.0
 		 * @param string $location defines the location.
 		 */

--- a/includes/class-wcj-product-open-pricing.php
+++ b/includes/class-wcj-product-open-pricing.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Product Open Pricing
  *
- * @version 5.6.3-dev
+ * @version 5.6.3
  * @since   2.4.8
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -221,7 +221,7 @@ if ( ! class_exists( 'WCJ_Product_Open_Pricing' ) ) :
 		/**
 		 * Add_notice_query_var.
 		 *
-		 * @version 5.6.3-dev
+		 * @version 5.6.3
 		 * @since   2.4.8
 		 * @param string $location defines the location.
 		 */

--- a/includes/class-wcj-product-open-pricing.php
+++ b/includes/class-wcj-product-open-pricing.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Product Open Pricing
  *
- * @version 5.6.2
+ * @version 5.6.3-dev
  * @since   2.4.8
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -221,13 +221,13 @@ if ( ! class_exists( 'WCJ_Product_Open_Pricing' ) ) :
 		/**
 		 * Add_notice_query_var.
 		 *
-		 * @version 5.5.9
+		 * @version 5.6.3-dev
 		 * @since   2.4.8
 		 * @param string $location defines the location.
 		 */
 		public function add_notice_query_var( $location ) {
 			remove_filter( 'redirect_post_location', array( $this, 'add_notice_query_var' ), 99 );
-			return esc_url( add_query_arg( array( 'wcj_product_open_price_admin_notice' => true ), $location ) );
+			return esc_url_raw( add_query_arg( array( 'wcj_product_open_price_admin_notice' => true ), $location ) );
 		}
 
 		/**

--- a/includes/class-wcj-product-price-by-formula.php
+++ b/includes/class-wcj-product-price-by-formula.php
@@ -433,7 +433,7 @@ if ( ! class_exists( 'WCJ_Product_Price_By_Formula' ) ) :
 		 */
 		public function add_notice_query_var( $location ) {
 			remove_filter( 'redirect_post_location', array( $this, 'add_notice_query_var' ), 99 );
-			return add_query_arg( array( 'wcj_product_price_by_formula_admin_notice' => true ), $location );
+			return esc_url_raw( add_query_arg( array( 'wcj_product_price_by_formula_admin_notice' => true ), $location ) );
 		}
 
 		/**

--- a/includes/class-wcj-product-tabs.php
+++ b/includes/class-wcj-product-tabs.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Product Tabs
  *
- * @version 5.6.2
+ * @version 5.6.3-dev
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
  */
@@ -567,7 +567,7 @@ if ( ! class_exists( 'WCJ_Product_Tabs' ) ) :
 		/**
 		 * Save_custom_tabs_meta_box.
 		 *
-		 * @version 5.6.2
+		 * @version 5.6.3-dev
 		 * @todo    rewrite as standard `WCJ_Module` function
 		 * @param int            $post_id defines the post_id.
 		 * @param string | array $post defines the post.
@@ -597,7 +597,7 @@ if ( ! class_exists( 'WCJ_Product_Tabs' ) ) :
 				if ( $this->is_local_tab_visible( $i, $post_id ) ) {
 					foreach ( $option_names as $option_name ) {
 						$sanitized_option_name = $wpnonce && isset( $_POST[ $option_name . $i ] ) ? sanitize_text_field( wp_unslash( $_POST[ $option_name . $i ] ) ) : '';
-						update_post_meta( $post_id, '_' . $option_name . $i, sanitize_text_field( wp_unslash( $sanitized_option_name ) ) );
+						update_post_meta( $post_id, '_' . $option_name . $i, wp_kses_post( wp_unslash( $_POST[ $option_name . $i ] ) ) );
 					}
 				}
 			}

--- a/includes/class-wcj-product-tabs.php
+++ b/includes/class-wcj-product-tabs.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Product Tabs
  *
- * @version 5.6.3-dev
+ * @version 5.6.3
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
  */
@@ -567,7 +567,7 @@ if ( ! class_exists( 'WCJ_Product_Tabs' ) ) :
 		/**
 		 * Save_custom_tabs_meta_box.
 		 *
-		 * @version 5.6.3-dev
+		 * @version 5.6.3
 		 * @todo    rewrite as standard `WCJ_Module` function
 		 * @param int            $post_id defines the post_id.
 		 * @param string | array $post defines the post.

--- a/includes/class-wcj-purchase-data.php
+++ b/includes/class-wcj-purchase-data.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Cost of Goods (formerly Product Cost Price)
  *
- * @version 5.6.3-dev
+ * @version 5.6.3
  * @since   2.2.0
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -277,7 +277,7 @@ if ( ! class_exists( 'WCJ_Purchase_Data' ) ) :
 		/**
 		 * Create_meta_box.
 		 *
-		 * @version 5.6.3-dev
+		 * @version 5.6.3
 		 * @since   2.4.5
 		 * @todo    (maybe) min_profit
 		 */

--- a/includes/class-wcj-purchase-data.php
+++ b/includes/class-wcj-purchase-data.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Cost of Goods (formerly Product Cost Price)
  *
- * @version 5.6.2
+ * @version 5.6.3-dev
  * @since   2.2.0
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -248,7 +248,7 @@ if ( ! class_exists( 'WCJ_Purchase_Data' ) ) :
 						$product_id     = ( isset( $item['variation_id'] ) && 0 !== $item['variation_id'] && 'no' === wcj_get_option( 'wcj_purchase_data_variable_as_simple_enabled', 'no' )
 						? $item['variation_id'] : $item['product_id'] );
 						$purchase_price = wc_get_product_purchase_price( $product_id );
-						if ( 0 !== ( $purchase_price ) && '0' !== ( $purchase_price ) ) {
+						if ( (float) 0 !== $purchase_price ) {
 							if ( 'profit' === $column ) {
 								$_order_prices_include_tax = ( WCJ_IS_WC_VERSION_BELOW_3 ? $the_order->prices_include_tax : $the_order->get_prices_include_tax() );
 								$line_total                = ( $_order_prices_include_tax ) ? ( $item['line_total'] + $item['line_tax'] ) : $item['line_total'];
@@ -262,7 +262,7 @@ if ( ! class_exists( 'WCJ_Purchase_Data' ) ) :
 						$total += $value;
 					}
 				}
-				if ( 0 > $total ) {
+				if ( 0 !== $total ) {
 					if ( ! $is_forecasted ) {
 						echo '<span style="color:green;">';
 					}
@@ -277,7 +277,7 @@ if ( ! class_exists( 'WCJ_Purchase_Data' ) ) :
 		/**
 		 * Create_meta_box.
 		 *
-		 * @version 5.6.2
+		 * @version 5.6.3-dev
 		 * @since   2.4.5
 		 * @todo    (maybe) min_profit
 		 */
@@ -300,10 +300,13 @@ if ( ! class_exists( 'WCJ_Purchase_Data' ) ) :
 			}
 			foreach ( $products as $product_id => $desc ) {
 				$purchase_price = wc_get_product_purchase_price( $product_id );
-				if ( 0 > $purchase_price ) {
+				if ( $purchase_price <= 0 ) {
+					$purchase_price = 0;
+				}
+				if ( 0 !== $purchase_price && '0' !== $purchase_price && '' !== $purchase_price ) {
 					$the_product = wc_get_product( $product_id );
 					$the_price   = $the_product->get_price();
-					if ( 0 > $the_price ) {
+					if ( 0 !== $the_price && '0' !== $the_price && '' !== $the_price ) {
 						$the_profit   = $the_price - $purchase_price;
 						$table_data   = array();
 						$table_data[] = array( __( 'Selling', 'woocommerce-jetpack' ), wc_price( $the_price ) );

--- a/includes/classes/class-wcj-module.php
+++ b/includes/classes/class-wcj-module.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce Module
  *
- * @version 5.6.2
+ * @version 5.6.3-dev
  * @since   2.2.0
  * @author  Pluggabl LLC.
  * @todo    [dev] maybe should be `abstract` ?
@@ -358,13 +358,13 @@ if ( ! class_exists( 'WCJ_Module' ) ) :
 		/**
 		 * Validate_value_add_notice_query_var.
 		 *
-		 * @version 5.5.9
+		 * @version 5.6.3-dev
 		 * @since   2.9.1
 		 * @param String $location Get location.
 		 */
 		public function validate_value_add_notice_query_var( $location ) {
 			remove_filter( 'redirect_post_location', array( $this, 'validate_value_add_notice_query_var' ), 99 );
-			return add_query_arg( array( 'wcj_' . $this->id . '_meta_box_admin_notice' => true ), $location );
+			return esc_url_raw( add_query_arg( array( 'wcj_' . $this->id . '_meta_box_admin_notice' => true ), $location ) );
 		}
 
 		/**
@@ -493,13 +493,13 @@ if ( ! class_exists( 'WCJ_Module' ) ) :
 		/**
 		 * Add_notice_query_var.
 		 *
-		 * @version 5.5.9
+		 * @version 5.6.3-dev
 		 * @since   2.5.3
 		 *  @param String $location Get location.
 		 */
 		public function add_notice_query_var( $location ) {
 			remove_filter( 'redirect_post_location', array( $this, 'add_notice_query_var' ), 99 );
-			return esc_url( add_query_arg( array( 'wcj_' . $this->id . '_admin_notice' => true ), $location ) );
+			return esc_url_raw( add_query_arg( array( 'wcj_' . $this->id . '_admin_notice' => true ), $location ) );
 		}
 
 		/**
@@ -635,12 +635,18 @@ if ( ! class_exists( 'WCJ_Module' ) ) :
 			setup_postdata( $_post );
 			// Save options.
 			foreach ( $this->get_meta_box_options() as $option ) {
-				if ( ! $option || '' === $option || 'title' === $option['type'] ) {
+				if ( 'title' === $option['type'] ) {
 					continue;
 				}
 				$is_enabled = ( isset( $option['enabled'] ) && 'no' === $option['enabled'] ) ? false : true;
 				if ( $is_enabled ) {
-					$option_value  = ( isset( $_POST[ $option['name'] ] ) ) ? sanitize_text_field( wp_unslash( $_POST[ $option['name'] ] ) ) : ( isset( $option['default'] ) ? $option['default'] : '' ); // phpcs:ignore WordPress.Security.NonceVerification
+					$option_value = '';
+					$wpnonce      = wp_verify_nonce( wp_unslash( isset( $_POST['woocommerce_meta_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['woocommerce_meta_nonce'] ) ) : '' ), 'woocommerce_save_data' );
+					if ( $wpnonce && isset( $_POST[ $option['name'] ] ) ) {
+						$option_value = is_array( $_POST[ $option['name'] ] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST[ $option['name'] ] ) ) : sanitize_text_field( wp_unslash( $_POST[ $option['name'] ] ) );
+					} elseif ( isset( $option['default'] ) ) {
+						$option_value = $option['default'];
+					}
 					$the_post_id   = ( isset( $option['product_id'] ) ) ? $option['product_id'] : $post_id;
 					$the_meta_name = ( isset( $option['meta_name'] ) ) ? $option['meta_name'] : '_' . $option['name'];
 					if ( isset( $option['convert'] ) && 'from_date_to_timestamp' === $option['convert'] ) {

--- a/includes/classes/class-wcj-module.php
+++ b/includes/classes/class-wcj-module.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce Module
  *
- * @version 5.6.3-dev
+ * @version 5.6.3
  * @since   2.2.0
  * @author  Pluggabl LLC.
  * @todo    [dev] maybe should be `abstract` ?
@@ -358,7 +358,7 @@ if ( ! class_exists( 'WCJ_Module' ) ) :
 		/**
 		 * Validate_value_add_notice_query_var.
 		 *
-		 * @version 5.6.3-dev
+		 * @version 5.6.3
 		 * @since   2.9.1
 		 * @param String $location Get location.
 		 */
@@ -493,7 +493,7 @@ if ( ! class_exists( 'WCJ_Module' ) ) :
 		/**
 		 * Add_notice_query_var.
 		 *
-		 * @version 5.6.3-dev
+		 * @version 5.6.3
 		 * @since   2.5.3
 		 *  @param String $location Get location.
 		 */

--- a/includes/functions/wcj-functions-general.php
+++ b/includes/functions/wcj-functions-general.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Functions - General
  *
- * @version 5.6.3-dev
+ * @version 5.6.3
  * @author  Pluggabl LLC.
  * @todo    add `wcj_add_actions()` and `wcj_add_filters()`
  * @package Booster_For_WooCommerce/functions
@@ -1035,7 +1035,7 @@ if ( ! function_exists( 'wcj_add_allowed_html' ) ) {
 	/**
 	 * Wcj_add_allowed_html.
 	 *
-	 * @version 5.6.3-dev
+	 * @version 5.6.3
 	 * @since   5.6.0
 	 * @param array  $allowed_html to get default allowed html.
 	 * @param string $context to get default context.

--- a/includes/functions/wcj-functions-general.php
+++ b/includes/functions/wcj-functions-general.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Functions - General
  *
- * @version 5.6.2
+ * @version 5.6.3-dev
  * @author  Pluggabl LLC.
  * @todo    add `wcj_add_actions()` and `wcj_add_filters()`
  * @package Booster_For_WooCommerce/functions
@@ -1035,7 +1035,7 @@ if ( ! function_exists( 'wcj_add_allowed_html' ) ) {
 	/**
 	 * Wcj_add_allowed_html.
 	 *
-	 * @version 5.6.2
+	 * @version 5.6.3-dev
 	 * @since   5.6.0
 	 * @param array  $allowed_html to get default allowed html.
 	 * @param string $context to get default context.
@@ -1054,6 +1054,8 @@ if ( ! function_exists( 'wcj_add_allowed_html' ) ) {
 				'dateformat'                => true,
 				'mindate'                   => true,
 				'maxdate'                   => true,
+				'excludemonths'             => true,
+				'excludedays'               => true,
 				'firstday'                  => true,
 				'display'                   => true,
 				'required'                  => true,
@@ -1071,6 +1073,8 @@ if ( ! function_exists( 'wcj_add_allowed_html' ) ) {
 				'currentday_time_limit'     => true,
 				'data-blocked_dates_format' => true,
 				'onclick'                   => true,
+				'accept'                    => true,
+				'data-*'                    => true,
 			),
 			'textarea' => array(
 				'name'        => true,
@@ -1133,9 +1137,22 @@ if ( ! function_exists( 'wcj_add_allowed_html' ) ) {
 				'style'    => true,
 				'class'    => true,
 				'disabled' => true,
+				'onclick'  => true,
+				'wcj_data' => true,
 			),
 			'style'    => array(
 				'type' => true,
+			),
+			'script'   => array(
+				'type'           => true,
+				'async'          => true,
+				'crossorigin'    => true,
+				'defer'          => true,
+				'integrity'      => true,
+				'nomodule'       => true,
+				'referrerpolicy' => true,
+				'src'            => true,
+				'type'           => true,
 			),
 			'a'        => array(
 				'onclick'       => true,
@@ -1145,12 +1162,14 @@ if ( ! function_exists( 'wcj_add_allowed_html' ) ) {
 				'target'        => true,
 				'wcj-copy-data' => true,
 			),
-			'button'   => array(
-				'wcj_data' => true,
+			'details'  => array(
+				'open' => true,
 			),
+			'bdi'      => true,
+			'em'       => true,
 		);
 		$allowed_merged_html = array_merge_recursive( $allowed_html, $allowed_extra_html );
 		return $allowed_merged_html;
 	}
-	add_filter( 'wp_kses_allowed_html', 'wcj_add_allowed_html', 10, 2 );
+	add_filter( 'wp_kses_allowed_html', 'wcj_add_allowed_html', PHP_INT_MAX, 2 );
 }

--- a/includes/input-fields/class-wcj-product-input-fields-core.php
+++ b/includes/input-fields/class-wcj-product-input-fields-core.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Product Input Fields - Core
  *
- * @version 5.6.2
+ * @version 5.6.3
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
  */
@@ -155,7 +155,7 @@ if ( ! class_exists( 'WCJ_Product_Input_Fields_Core' ) ) :
 		/**
 		 * Save product input fields on Product Edit.
 		 *
-		 * @version 5.6.2
+		 * @version 5.6.3
 		 * @param int         $post_id Get post ID.
 		 * @param obj | Array $post Get post.
 		 */
@@ -177,7 +177,7 @@ if ( ! class_exists( 'WCJ_Product_Input_Fields_Core' ) ) :
 				foreach ( $options as $option ) {
 					$option_name = str_replace( 'wcj_product_input_fields_', '', $option['id'] . $i );
 					if ( isset( $_POST[ $option['id'] . $i ] ) ) {
-						$values[ $option_name ] = isset( $_POST[ $option['id'] . $i ] ) ? sanitize_text_field( wp_unslash( $_POST[ $option['id'] . $i ] ) ) : '';
+						$values[ $option_name ] = isset( $_POST[ $option['id'] . $i ] ) ? wp_kses_post( wp_unslash( $_POST[ $option['id'] . $i ] ) ) : '';
 					} elseif ( 'checkbox' === $option['type'] ) {
 						$values[ $option_name ] = 'off';
 					}

--- a/includes/mini-plugin/wcj-mini-plugin.php
+++ b/includes/mini-plugin/wcj-mini-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Mini plugin customizations
  *
- * @version 5.6.3-dev
+ * @version 5.6.3
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/mini-plugin
  */

--- a/includes/mini-plugin/wcj-mini-plugin.php
+++ b/includes/mini-plugin/wcj-mini-plugin.php
@@ -2,6 +2,90 @@
 /**
  * Booster for WooCommerce - Mini plugin customizations
  *
+ * @version 5.6.3-dev
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/mini-plugin
  */
+
+add_filter(
+	'wcj_modules',
+	function ( $modules_cats ) {
+		$modules_cats     = array_filter(
+			$modules_cats,
+			function ( $item ) {
+				return in_array( $item, array( 'emails_and_misc', 'pdf_invoicing', 'shipping_and_orders', 'payment_gateways', 'cart_and_checkout', 'products', 'labels', 'prices_and_currencies', 'labels', 'pdf_invoicing', 'dashboard' ), true );
+			},
+			ARRAY_FILTER_USE_KEY
+		);
+		$all_cat_ids1     = array( 'price_by_country', 'multicurrency', 'multicurrency_base_price', 'currency_per_product', 'currency', 'currency_external_products', 'bulk_price_converter', 'wholesale_price', 'product_open_pricing', 'offer_price', 'price_by_user_role', 'product_price_by_formula', 'global_discount', 'currency_exchange_rates', 'price_formats', 'price_labels', 'call_for_price', 'free_price', 'add_to_cart', 'more_button_labels', 'product_listings', 'tax_display', 'admin_products_list', 'products_per_page', 'product_tabs', 'product_custom_info', 'related_products', 'cross_sells', 'upsells', 'sorting', 'sku', 'stock', 'product_input_fields', 'product_add_to_cart', 'add_to_cart_button_visibility', 'purchase_data', 'product_bookings', 'crowdfunding', 'product_addons', 'product_images', 'sale_flash', 'product_by_country', 'product_by_user_role', 'product_custom_visibility', 'product_by_time', 'product_by_date', 'product_by_user', 'products_xml', 'product_bulk_meta_editor', 'product_msrp', 'product_extra_fees', 'cart', 'cart_customization', 'empty_cart', 'mini_cart', 'url_coupons', 'coupon_code_generator', 'coupon_by_user_role', 'checkout_core_fields', 'checkout_custom_fields', 'checkout_files_upload', 'checkout_custom_info', 'checkout_customization', 'checkout_fees', 'eu_vat_number', 'frequently_bought_together', 'one_page_checkout', 'payment_gateways', 'payment_gateways_icons', 'payment_gateways_fees', 'payment_gateways_per_category', 'payment_gateways_currency', 'payment_gateways_by_currency', 'payment_gateways_min_max', 'payment_gateways_by_country', 'payment_gateways_by_user_role', 'payment_gateways_by_shipping', 'shipping', 'shipping_options', 'shipping_icons', 'shipping_description', 'shipping_time', 'left_to_free_shipping', 'shipping_calculator', 'shipping_by_user_role', 'shipping_by_products', 'shipping_by_cities', 'shipping_by_time', 'shipping_by_order_amount', 'shipping_by_order_qty', 'address_formats', 'orders', 'admin_orders_list', 'order_min_amount', 'order_numbers', 'order_custom_statuses', 'order_quantities', 'max_products_per_user', 'pdf_invoicing', 'pdf_invoicing_numbering', 'pdf_invoicing_templates', 'pdf_invoicing_header', 'pdf_invoicing_footer', 'pdf_invoicing_styling', 'pdf_invoicing_page', 'pdf_invoicing_emails', 'pdf_invoicing_paid_stamp', 'pdf_invoicing_display', 'pdf_invoicing_advanced', 'pdf_invoicing_extra_columns', 'general', 'breadcrumbs', 'admin_bar', 'export', 'my_account', 'old_slugs', 'reports', 'admin_tools', 'debug_tools', 'emails', 'email_options', 'emails_verification', 'wpml', 'custom_css', 'custom_js', 'custom_php', 'track_users', 'modules_by_user_roles', 'template_editor', 'product_info' );
+		$modules_all_cats = $modules_cats;
+
+		// ----- Modules By User Roles Module Options Start -----
+		if ( ! function_exists( 'wp_get_current_user' ) ) {
+			require_once ABSPATH . 'wp-includes/pluggable.php';
+		}
+		$current_user = wp_get_current_user();
+
+		$wcj_modules_by_user_roles_data['role']         = ( isset( $current_user->roles ) && is_array( $current_user->roles ) && ! empty( $current_user->roles ) ?
+			reset( $current_user->roles ) : 'guest' );
+		$wcj_modules_by_user_roles_data['role']         = ( '' !== $wcj_modules_by_user_roles_data['role'] ? $wcj_modules_by_user_roles_data['role'] : 'guest' );
+		$wcj_modules_by_user_roles_data['modules_incl'] = wcj_get_option( 'wcj_modules_by_user_roles_incl_' . $wcj_modules_by_user_roles_data['role'], '' );
+		$wcj_modules_by_user_roles_data['modules_excl'] = wcj_get_option( 'wcj_modules_by_user_roles_excl_' . $wcj_modules_by_user_roles_data['role'], '' );
+
+		if ( empty( $wcj_modules_by_user_roles_data['modules_incl'] ) && empty( $wcj_modules_by_user_roles_data['modules_excl'] ) ) {
+			$all_cat_ids = $all_cat_ids1;
+		} elseif ( ! empty( $wcj_modules_by_user_roles_data['modules_incl'] ) && empty( $wcj_modules_by_user_roles_data['modules_excl'] ) ) {
+
+			$all_cat_ids = $wcj_modules_by_user_roles_data['modules_incl'];
+
+		} elseif ( empty( $wcj_modules_by_user_roles_data['modules_incl'] ) && ! empty( $wcj_modules_by_user_roles_data['modules_excl'] ) ) {
+			$array = $all_cat_ids1;
+
+			$value = $wcj_modules_by_user_roles_data['modules_excl'];
+			$array = array_diff( $array, $value );
+
+			$all_cat_ids = $array;
+		} elseif ( ! empty( $wcj_modules_by_user_roles_data['modules_incl'] ) && ! empty( $wcj_modules_by_user_roles_data['modules_excl'] ) ) {
+
+			$all_cat_ids = $wcj_modules_by_user_roles_data['modules_incl'];
+		}
+		// ----- Modules By User Roles Module Options End -----
+
+		if ( count( $all_cat_ids ) <= 1 && '' === $all_cat_ids[0] ) {
+			foreach ( $modules_cats as $key => $value ) {
+				$all_cat_ids = array_merge( $value['all_cat_ids'], $all_cat_ids );
+			}
+		} else {
+			foreach ( $modules_all_cats as $key => $modules_cat ) {
+				foreach ( $modules_cat as $cat_keys => $value ) {
+					if ( 'dashboard' === $key || 'all_cat_ids' !== $cat_keys ) {
+						continue;
+					}
+					$modules_cats[ $key ]['all_cat_ids'] = array();
+					foreach ( $value as $module ) {
+
+						if ( in_array( $module, $all_cat_ids, true ) ) {
+							array_push( $modules_cats[ $key ]['all_cat_ids'], $module );
+						}
+					}
+				}
+			}
+		}
+		add_filter(
+			'wcj_modules_loaded',
+			function( $modules ) use ( $all_cat_ids ) {
+				$modules = array_filter(
+					$modules,
+					function ( $item ) use ( $all_cat_ids ) {
+						return in_array( $item, $all_cat_ids, true );
+					},
+					ARRAY_FILTER_USE_KEY
+				);
+				return $modules;
+			},
+			10,
+			2
+		);
+		return $modules_cats;
+	}
+);

--- a/includes/pdf-invoices/class-wcj-pdf-invoicing-report-tool.php
+++ b/includes/pdf-invoices/class-wcj-pdf-invoicing-report-tool.php
@@ -431,23 +431,17 @@ if ( ! class_exists( 'WCJ_PDF_Invoicing_Report_Tool' ) ) :
 							$order_cart_total_excl_tax += $item->get_total();
 						}
 						$order_shipping_total_excl_tax = $the_order->get_shipping_total();
-						if($order_cart_total_excl_tax == 0 || $order_cart_tax == 0)
-						{
-							$order_cart_tax_percent = 0;
-						}
-						else
-						{
-							$order_cart_tax_percent        = ( 0 === $order_cart_total_excl_tax ? 0 : $order_cart_tax / $order_cart_total_excl_tax );
-						}
-						
 
-						if($order_shipping_total_excl_tax == 0 || $order_shipping_tax == 0)
-						{
-							$order_shipping_tax_percent = 0;
+						if ( 0 === $order_cart_total_excl_tax || '0' === $order_cart_tax ) {
+							$order_cart_tax_percent = 0;
+						} else {
+							$order_cart_tax_percent = ( 0 === $order_cart_total_excl_tax ? 0 : $order_cart_tax / $order_cart_total_excl_tax );
 						}
-						else
-						{
-							$order_shipping_tax_percent    = ( 0 === $order_shipping_total_excl_tax ? 0 : $order_shipping_tax / $order_shipping_total_excl_tax );
+
+						if ( 0 === $order_shipping_total_excl_tax || '0' === $order_shipping_tax ) {
+							$order_shipping_tax_percent = 0;
+						} else {
+							$order_shipping_tax_percent = ( 0 === $order_shipping_total_excl_tax ? 0 : $order_shipping_tax / $order_shipping_total_excl_tax );
 						}
 
 						$row = array();

--- a/includes/pdf-invoices/class-wcj-pdf-invoicing-report-tool.php
+++ b/includes/pdf-invoices/class-wcj-pdf-invoicing-report-tool.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - PDF Invoicing - Report Tool
  *
- * @version 5.6.2
+ * @version 5.6.3
  * @since   2.2.1
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -353,7 +353,7 @@ if ( ! class_exists( 'WCJ_PDF_Invoicing_Report_Tool' ) ) :
 		/**
 		 * Invoices Report Data function.
 		 *
-		 * @version 5.6.2
+		 * @version 5.6.3
 		 * @since   2.5.7
 		 * @param int | string $year Get year.
 		 * @param int | string $month Get month.
@@ -431,8 +431,24 @@ if ( ! class_exists( 'WCJ_PDF_Invoicing_Report_Tool' ) ) :
 							$order_cart_total_excl_tax += $item->get_total();
 						}
 						$order_shipping_total_excl_tax = $the_order->get_shipping_total();
-						$order_cart_tax_percent        = ( 0 === $order_cart_total_excl_tax ? 0 : $order_cart_tax / $order_cart_total_excl_tax );
-						$order_shipping_tax_percent    = ( 0 === $order_shipping_total_excl_tax ? 0 : $order_shipping_tax / $order_shipping_total_excl_tax );
+						if($order_cart_total_excl_tax == 0 || $order_cart_tax == 0)
+						{
+							$order_cart_tax_percent = 0;
+						}
+						else
+						{
+							$order_cart_tax_percent        = ( 0 === $order_cart_total_excl_tax ? 0 : $order_cart_tax / $order_cart_total_excl_tax );
+						}
+						
+
+						if($order_shipping_total_excl_tax == 0 || $order_shipping_tax == 0)
+						{
+							$order_shipping_tax_percent = 0;
+						}
+						else
+						{
+							$order_shipping_tax_percent    = ( 0 === $order_shipping_total_excl_tax ? 0 : $order_shipping_tax / $order_shipping_total_excl_tax );
+						}
 
 						$row = array();
 						foreach ( $columns as $column ) {

--- a/includes/shortcodes/class-wcj-orders-shortcodes.php
+++ b/includes/shortcodes/class-wcj-orders-shortcodes.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Shortcodes - Orders
  *
- * @version 5.6.3-dev
+ * @version 5.6.3
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/shortcodes
  */
@@ -20,7 +20,7 @@ if ( ! class_exists( 'WCJ_Orders_Shortcodes' ) ) :
 		/**
 		 * Constructor.
 		 *
-		 * @version 5.6.3-dev
+		 * @version 5.6.3
 		 */
 		public function __construct() {
 
@@ -481,7 +481,7 @@ if ( ! class_exists( 'WCJ_Orders_Shortcodes' ) ) :
 		/**
 		 * Wcj_order_total_refunded.
 		 *
-		 * @version 5.6.3-dev
+		 * @version 5.6.3
 		 * @since   2.5.3
 		 * @param array $atts The user defined shortcode attributes.
 		 */
@@ -493,7 +493,7 @@ if ( ! class_exists( 'WCJ_Orders_Shortcodes' ) ) :
 		/**
 		 * Wcj_order_item_total_refunded.
 		 *
-		 * @version 5.6.3-dev
+		 * @version 5.6.3
 		 * @since   2.5.3
 		 * @param array $atts The user defined shortcode attributes.
 		 */
@@ -1512,6 +1512,7 @@ if ( ! class_exists( 'WCJ_Orders_Shortcodes' ) ) :
 			} else {
 				$the_items          = $this->the_order->get_items();
 				$exclude_item_total = 0;
+				$exclude_item_subtotal = 0;
 
 				foreach ( $the_items as $item_id => $item ) {
 					$the_product = $item->get_product( $item );

--- a/includes/shortcodes/class-wcj-orders-shortcodes.php
+++ b/includes/shortcodes/class-wcj-orders-shortcodes.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Shortcodes - Orders
  *
- * @version 5.6.2
+ * @version 5.6.3-dev
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/shortcodes
  */
@@ -20,7 +20,7 @@ if ( ! class_exists( 'WCJ_Orders_Shortcodes' ) ) :
 		/**
 		 * Constructor.
 		 *
-		 * @version 5.4.0
+		 * @version 5.6.3-dev
 		 */
 		public function __construct() {
 
@@ -93,6 +93,7 @@ if ( ! class_exists( 'WCJ_Orders_Shortcodes' ) ) :
 				'wcj_order_total_length',
 				'wcj_order_total_shipping_refunded',
 				'wcj_order_total_refunded',
+				'wcj_order_item_total_refunded',
 				'wcj_order_total_tax',
 				'wcj_order_total_tax_after_refund',
 				'wcj_order_total_tax_without_html_custom',
@@ -480,13 +481,33 @@ if ( ! class_exists( 'WCJ_Orders_Shortcodes' ) ) :
 		/**
 		 * Wcj_order_total_refunded.
 		 *
-		 * @version 5.6.2
+		 * @version 5.6.3-dev
 		 * @since   2.5.3
 		 * @param array $atts The user defined shortcode attributes.
 		 */
 		public function wcj_order_total_refunded( $atts ) {
 			$refund_total = ( $atts['excl_tax'] ) ? $this->the_order->get_total_refunded() - $this->the_order->get_total_tax_refunded() : $this->the_order->get_total_refunded();
 			return $this->wcj_price_shortcode( $refund_total, $atts );
+		}
+
+		/**
+		 * Wcj_order_item_total_refunded.
+		 *
+		 * @version 5.6.3-dev
+		 * @since   2.5.3
+		 * @param array $atts The user defined shortcode attributes.
+		 */
+		public function wcj_order_item_total_refunded( $atts ) {
+			$refund_item = $this->the_order->get_refunds();
+			foreach ( $refund_item as $_refund ) {
+
+				foreach ( $_refund->get_items() as $_item ) {
+					$refund_total     = $_item->get_total();
+					$refund_total_tax = $_item->get_total_tax();
+				}
+			}
+			$refund_result = ( $atts['excl_tax'] ) ? abs( $refund_total ) : abs( $refund_total ) + abs( $refund_total_tax );
+			return $this->wcj_price_shortcode( $refund_result, $atts );
 		}
 
 		/**

--- a/includes/shortcodes/class-wcj-orders-shortcodes.php
+++ b/includes/shortcodes/class-wcj-orders-shortcodes.php
@@ -1510,8 +1510,8 @@ if ( ! class_exists( 'WCJ_Orders_Shortcodes' ) ) :
 					$the_subtotal += $this->the_order->get_line_subtotal( $item, false, true );
 				}
 			} else {
-				$the_items          = $this->the_order->get_items();
-				$exclude_item_total = 0;
+				$the_items             = $this->the_order->get_items();
+				$exclude_item_total    = 0;
 				$exclude_item_subtotal = 0;
 
 				foreach ( $the_items as $item_id => $item ) {

--- a/langs/woocommerce-jetpack.pot
+++ b/langs/woocommerce-jetpack.pot
@@ -10,7 +10,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.3\n"
+"X-Generator: Poedit 2.0.6\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: __;_e;__ngettext:1,2;_n:1,2;__ngettext_noop:1,2;"
 "_n_noop:1,2;_c;_nc:4c,1,2;_x:1,2c;_nx:4c,1,2;_nx_noop:4c,1,2;_ex:1,2c;"
@@ -36,14 +36,14 @@ msgstr ""
 #: includes/admin/class-wc-settings-jetpack.php:33
 #: includes/admin/class-wc-settings-jetpack.php:400
 #: includes/class-wcj-admin-bar.php:299
-#: includes/class-wcj-checkout-files-upload.php:270
+#: includes/class-wcj-checkout-files-upload.php:273
 #: includes/class-wcj-eu-vat-number.php:179
 #: includes/class-wcj-max-products-per-user.php:217
 #: includes/class-wcj-orders.php:133 includes/class-wcj-orders.php:170
 #: includes/class-wcj-payment-gateways.php:102
 #: includes/class-wcj-track-users.php:174 includes/class-wcj-track-users.php:265
-#: includes/classes/class-wcj-module.php:672
-#: includes/classes/class-wcj-module.php:881
+#: includes/classes/class-wcj-module.php:678
+#: includes/classes/class-wcj-module.php:887
 #: includes/settings/wcj-settings-price-by-country.php:259
 msgid "Booster"
 msgstr ""
@@ -206,7 +206,7 @@ msgstr ""
 #: includes/admin/class-wc-settings-jetpack.php:631
 #: includes/admin/class-wc-settings-jetpack.php:1084
 #: includes/class-wcj-admin-bar.php:188
-#: includes/classes/class-wcj-module.php:1029
+#: includes/classes/class-wcj-module.php:1035
 msgid "Documentation"
 msgstr ""
 
@@ -993,7 +993,7 @@ msgstr ""
 
 #: includes/class-wcj-admin-bar.php:267 includes/class-wcj-admin-bar.php:311
 #: includes/class-wcj-admin-bar.php:659
-#: includes/classes/class-wcj-module.php:852
+#: includes/classes/class-wcj-module.php:858
 #: includes/settings/wcj-settings-wpml.php:97
 msgid "Tools"
 msgstr ""
@@ -1574,87 +1574,88 @@ msgstr ""
 msgid "Let customers upload files on (or after) the checkout."
 msgstr ""
 
-#: includes/class-wcj-checkout-files-upload.php:81
-#: includes/class-wcj-checkout-files-upload.php:86
+#: includes/class-wcj-checkout-files-upload.php:84
+#: includes/class-wcj-checkout-files-upload.php:89
 #: includes/settings/wcj-settings-checkout-files-upload.php:397
 #: includes/settings/wcj-settings-checkout-files-upload.php:446
 #, php-format
 msgid "File: %s"
 msgstr ""
 
-#: includes/class-wcj-checkout-files-upload.php:213
+#: includes/class-wcj-checkout-files-upload.php:216
 #: includes/settings/wcj-settings-checkout-files-upload.php:126
 msgid "File is required!"
 msgstr ""
 
-#: includes/class-wcj-checkout-files-upload.php:232
-#: includes/class-wcj-checkout-files-upload.php:247
-#: includes/class-wcj-checkout-files-upload.php:508
-#: includes/class-wcj-checkout-files-upload.php:524
+#: includes/class-wcj-checkout-files-upload.php:235
+#: includes/class-wcj-checkout-files-upload.php:250
+#: includes/class-wcj-checkout-files-upload.php:519
+#: includes/class-wcj-checkout-files-upload.php:535
 #: includes/settings/wcj-settings-checkout-files-upload.php:120
 #, php-format
 msgid "Wrong file type: \"%s\"!"
 msgstr ""
 
-#: includes/class-wcj-checkout-files-upload.php:270
+#: includes/class-wcj-checkout-files-upload.php:273
 msgid "Uploaded Files"
 msgstr ""
 
-#: includes/class-wcj-checkout-files-upload.php:303
+#: includes/class-wcj-checkout-files-upload.php:306
 msgid "No files uploaded."
 msgstr ""
 
-#: includes/class-wcj-checkout-files-upload.php:306
+#: includes/class-wcj-checkout-files-upload.php:309
 msgid "Delete all files"
 msgstr ""
 
-#: includes/class-wcj-checkout-files-upload.php:393
+#: includes/class-wcj-checkout-files-upload.php:400
 #: includes/settings/wcj-settings-checkout-files-upload.php:260
 msgid "Files were successfully removed."
 msgstr ""
 
-#: includes/class-wcj-checkout-files-upload.php:422
+#: includes/class-wcj-checkout-files-upload.php:429
 msgid "Booster for WooCommerce: Checkout Files Upload: %action%"
 msgstr ""
 
-#: includes/class-wcj-checkout-files-upload.php:424
-msgid "Order ID: %order_id%; File name: %file_name%"
+#: includes/class-wcj-checkout-files-upload.php:432
+#, php-format
+msgid "Order ID: %1$s; File name: %2$s"
 msgstr ""
 
-#: includes/class-wcj-checkout-files-upload.php:441
-#: includes/class-wcj-checkout-files-upload.php:478
+#: includes/class-wcj-checkout-files-upload.php:452
+#: includes/class-wcj-checkout-files-upload.php:489
 #: includes/settings/wcj-settings-checkout-files-upload.php:150
 #, php-format
 msgid "File \"%s\" was successfully removed."
 msgstr ""
 
-#: includes/class-wcj-checkout-files-upload.php:453
+#: includes/class-wcj-checkout-files-upload.php:464
 msgid "File Removed"
 msgstr ""
 
-#: includes/class-wcj-checkout-files-upload.php:544
+#: includes/class-wcj-checkout-files-upload.php:555
 #: includes/settings/wcj-settings-checkout-files-upload.php:135
 #, php-format
 msgid "File \"%s\" was successfully uploaded."
 msgstr ""
 
-#: includes/class-wcj-checkout-files-upload.php:559
+#: includes/class-wcj-checkout-files-upload.php:570
 msgid "File Uploaded"
 msgstr ""
 
-#: includes/class-wcj-checkout-files-upload.php:587
+#: includes/class-wcj-checkout-files-upload.php:598
 #: includes/settings/wcj-settings-checkout-files-upload.php:141
 msgid "Please select file to upload!"
 msgstr ""
 
-#: includes/class-wcj-checkout-files-upload.php:898
-#: includes/class-wcj-checkout-files-upload.php:899
+#: includes/class-wcj-checkout-files-upload.php:896
+#: includes/class-wcj-checkout-files-upload.php:897
 #: includes/settings/wcj-settings-checkout-files-upload.php:105
 msgid "Upload"
 msgstr ""
 
-#: includes/class-wcj-checkout-files-upload.php:914
-#: includes/class-wcj-checkout-files-upload.php:915
+#: includes/class-wcj-checkout-files-upload.php:912
+#: includes/class-wcj-checkout-files-upload.php:913
 #: includes/settings/wcj-settings-checkout-files-upload.php:111
 #: includes/settings/wcj-settings-price-by-user-role.php:81
 #: includes/settings/wcj-settings-price-by-user-role.php:89
@@ -3982,7 +3983,7 @@ msgstr ""
 #: includes/class-wcj-product-bulk-meta-editor.php:315
 #: includes/class-wcj-product-by-user.php:287
 #: includes/class-wcj-purchase-data.php:125
-#: includes/classes/class-wcj-module.php:994
+#: includes/classes/class-wcj-module.php:1000
 #: includes/functions/wcj-functions-general.php:208
 #: includes/functions/wcj-functions-html.php:131
 #: includes/reports/class-wcj-reports-monthly-sales.php:393
@@ -5011,7 +5012,7 @@ msgstr ""
 
 #: includes/class-wcj-purchase-data.php:158
 #: includes/class-wcj-purchase-data.php:223
-#: includes/class-wcj-purchase-data.php:312
+#: includes/class-wcj-purchase-data.php:315
 #: includes/functions/wcj-functions-reports.php:31
 #: includes/settings/wcj-settings-purchase-data.php:152
 #: includes/settings/wcj-settings-purchase-data.php:180
@@ -5024,15 +5025,15 @@ msgstr ""
 msgid "Purchase Cost"
 msgstr ""
 
-#: includes/class-wcj-purchase-data.php:309
+#: includes/class-wcj-purchase-data.php:312
 msgid "Selling"
 msgstr ""
 
-#: includes/class-wcj-purchase-data.php:310
+#: includes/class-wcj-purchase-data.php:313
 msgid "Buying"
 msgstr ""
 
-#: includes/class-wcj-purchase-data.php:326
+#: includes/class-wcj-purchase-data.php:329
 msgid "Report"
 msgstr ""
 
@@ -5832,30 +5833,30 @@ msgid ""
 "\" products."
 msgstr ""
 
-#: includes/classes/class-wcj-module.php:766
+#: includes/classes/class-wcj-module.php:772
 #, php-format
 msgid "Selected: %s."
 msgstr ""
 
-#: includes/classes/class-wcj-module.php:837
+#: includes/classes/class-wcj-module.php:843
 msgid "Back to Module Settings"
 msgstr ""
 
-#: includes/classes/class-wcj-module.php:858
+#: includes/classes/class-wcj-module.php:864
 #: includes/settings/wcj-settings-wpml.php:102
 msgid "Module Tools"
 msgstr ""
 
-#: includes/classes/class-wcj-module.php:936
+#: includes/classes/class-wcj-module.php:942
 #: includes/settings/wcj-settings-checkout-core-fields.php:82
 msgid "enabled"
 msgstr ""
 
-#: includes/classes/class-wcj-module.php:937
+#: includes/classes/class-wcj-module.php:943
 msgid "disabled"
 msgstr ""
 
-#: includes/classes/class-wcj-module.php:945
+#: includes/classes/class-wcj-module.php:951
 #: includes/settings/wcj-settings-product-tabs.php:181
 #: includes/settings/wcj-settings-product-tabs.php:196
 #: includes/settings/wcj-settings-product-tabs.php:211
@@ -5863,27 +5864,27 @@ msgstr ""
 msgid "Deprecated"
 msgstr ""
 
-#: includes/classes/class-wcj-module.php:984
+#: includes/classes/class-wcj-module.php:990
 msgid "Reset Settings"
 msgstr ""
 
-#: includes/classes/class-wcj-module.php:990
+#: includes/classes/class-wcj-module.php:996
 msgid "Reset Module to Default Settings"
 msgstr ""
 
-#: includes/classes/class-wcj-module.php:991
+#: includes/classes/class-wcj-module.php:997
 msgid "Reset Submodule to Default Settings"
 msgstr ""
 
-#: includes/classes/class-wcj-module.php:995
+#: includes/classes/class-wcj-module.php:1001
 msgid "Reset settings"
 msgstr ""
 
-#: includes/classes/class-wcj-module.php:1033
+#: includes/classes/class-wcj-module.php:1039
 msgid "Module Options"
 msgstr ""
 
-#: includes/classes/class-wcj-module.php:1040
+#: includes/classes/class-wcj-module.php:1046
 msgid "Enable Module"
 msgstr ""
 
@@ -20604,7 +20605,7 @@ msgstr ""
 msgid "Attribute \"name\" is required!"
 msgstr ""
 
-#: includes/shortcodes/class-wcj-orders-shortcodes.php:394
+#: includes/shortcodes/class-wcj-orders-shortcodes.php:395
 #, php-format
 msgid "Refund #%1$s - %2$s"
 msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce customization, woocommerce bundle, woocommerce product addon, 
 Requires at least: 4.4
 Tested up to: 6.0.1
 Requires PHP: 5.6
-Stable tag: 5.6.2
+Stable tag: 5.6.3
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -274,6 +274,27 @@ To unlock all Booster for WooCommerce features, please install additional paid B
 * For support please visit the [Plugin Support Forum](https://wordpress.org/support/plugin/woocommerce-jetpack/).
 
 == Changelog ==
+
+= 5.6.3 31/08/2022 =
+
+* NEW FEATURE - PDF INVOICING & PACKING SLIPS - PDF Invoicing - Added a new shortcode for refund total with inc./ex. tax. [wcj_order_item_total_refunded excl_tax="yes" ]
+* FIXED - SHIPPING & ORDERS - Order Custom Statuses - Fixed custom status not displaying in order bulk action selection.
+* FIXED - PRODUCTS - Product Tabs - Fixed issue with HTML tags.
+* FIXED - PRODUCTS - Product Tabs - Fixed issue in some cases Jquery syntax was being shown.
+* FIXED - PRODUCTS - Product Visibility by User Role - Fixed allowed user role selection on the single product edit page.
+* FIXED - PRODUCTS - Product Visibility by Country - Fixed allowed country selection on the single product edit page.
+* FIXED - PRODUCTS - Cost of Goods - Fixed bugs related to reporting, profit, and other bugs.
+* FIXED - CART & CHECKOUT - Mini Cart Custom Info - Fixed Custom Info is not shown on the Wocommarce mini cart.
+* FIXED - BUTTON & PRICE LABELS - Free Price Labels - Fixed free price Label does not show when the product price is '0'.
+* FIXED - CART & CHECKOUT - Checkout Files Upload - Escaped the html content from the "File Upload Fields" value.
+* FIXED - EMAILS & MISC. - Modules By User Roles - Fixed Enable/disable modules by user roles.
+* FIXED - PRODUCTS - Product Addons - Fixed add-ons were not being saved with per product add-on.
+* FIXED - PRODUCTS - Product Input Fields - Fixed issue with input type radio for per product input field.
+* FIXED - PDF INVOICING & PACKING SLIPS - PDF Invoicing - Fixed Invoice report tool was showing an error while choosing the CSV option.
+* FIXED - EMAILS & MISC. - My Account - Added restriction for Cross browser scripting.
+* FIXED - PHP Warning: Undefined Variable "$exclude_item_subtotal" in /includes/shortcodes/class-wcj-shortcodes-orders.php ...
+* WooCommerce 6.8.2 tested
+* WordPress 6.0.1 Tested
 
 = 5.6.2 27/07/2022 =
 

--- a/version-details.json
+++ b/version-details.json
@@ -1,6 +1,6 @@
 {
-    "0" : "= 5.6.2 27/07/2022 =",
-    "1" : "* NEW FEATURE - PDF INVOICING & PACKING SLIPS - PDF Invoicing - Added a new shortcode Attribute to exclude tax in order to refund the Total. [wcj_order_shipping_price excl_tax=\"yes\" ]",
-    "2" : "* FIXED - SHIPPING & ORDERS - Maximum Products per User - Remove Max product per user meta from product while duplicating Product",
-    "3" : "* FIXED - EMAILS & MISC. - Export - Escape the html content from the \"Additional Export Orders Fields\" value. "
+    "0" : "= 5.6.3 31/08/2022 =",
+    "1" : "* NEW FEATURE - PDF INVOICING & PACKING SLIPS - PDF Invoicing - Added a new shortcode for refund total with inc./ex. tax. [wcj_order_item_total_refunded excl_tax=\"yes\" ]",
+    "2" : "* FIXED - SHIPPING & ORDERS - Order Custom Statuses - Fixed custom status not displaying in order bulk action selection.",
+    "3" : "* FIXED - PRODUCTS - Product Tabs - Fixed issue with HTML tags."
 }

--- a/woocommerce-jetpack.php
+++ b/woocommerce-jetpack.php
@@ -3,13 +3,13 @@
  * Plugin Name: Booster for WooCommerce
  * Plugin URI: https://booster.io
  * Description: Supercharge your WooCommerce site with these awesome powerful features. More than 100 modules.All in one WooCommerce plugin.
- * Version: 5.6.2
+ * Version: 5.6.3
  * Author: Pluggabl LLC
  * Author URI: https://booster.io
  * Text Domain: woocommerce-jetpack
  * Domain Path: /langs
  * Copyright: © 2020 Pluggabl LLC.
- * WC tested up to: 6.7.0
+ * WC tested up to: 6.8.2
  * License: GNU General Public License v3.0
  * php version 5.6
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -65,7 +65,7 @@ if ( ! class_exists( 'WC_Jetpack' ) ) :
 		 * @var   string
 		 * @since 2.4.7
 		 */
-		public $version = '5.6.2';
+		public $version = '5.6.3';
 
 		/**
 		 * The single instance of the class


### PR DESCRIPTION
= 5.6.3 31/08/2022 =

* NEW FEATURE - PDF INVOICING & PACKING SLIPS - PDF Invoicing - Added a new shortcode for refund total with inc./ex. tax. [wcj_order_item_total_refunded excl_tax="yes" ]
* FIXED - SHIPPING & ORDERS - Order Custom Statuses - Fixed custom status not displaying in order bulk action selection.
* FIXED - PRODUCTS - Product Tabs - Fixed issue with HTML tags.
* FIXED - PRODUCTS - Product Tabs - Fixed issue in some cases Jquery syntax was being shown.
* FIXED - PRODUCTS - Product Visibility by User Role - Fixed allowed user role selection on the single product edit page.
* FIXED - PRODUCTS - Product Visibility by Country - Fixed allowed country selection on the single product edit page.
* FIXED - PRODUCTS - Cost of Goods - Fixed bugs related to reporting, profit, and other bugs.
* FIXED - CART & CHECKOUT - Mini Cart Custom Info - Fixed Custom Info is not shown on the Wocommarce mini cart.
* FIXED - BUTTON & PRICE LABELS - Free Price Labels - Fixed free price Label does not show when the product price is '0'.
* FIXED - CART & CHECKOUT - Checkout Files Upload - Escaped the html content from the "File Upload Fields" value.
* FIXED - EMAILS & MISC. - Modules By User Roles - Fixed Enable/disable modules by user roles.
* FIXED - PRODUCTS - Product Addons - Fixed add-ons were not being saved with per product add-on.
* FIXED - PRODUCTS - Product Input Fields - Fixed issue with input type radio for per product input field.
* FIXED - PDF INVOICING & PACKING SLIPS - PDF Invoicing - Fixed Invoice report tool was showing an error while choosing the CSV option.
* FIXED - EMAILS & MISC. - My Account - Added restriction for Cross browser scripting.
* FIXED - PHP Warning: Undefined Variable "$exclude_item_subtotal" in /includes/shortcodes/class-wcj-shortcodes-orders.php ...
* WooCommerce 6.8.2 tested
* WordPress 6.0.1 Tested