### PR TITLE
v5.6.6

### DIFF
--- a/includes/class-wcj-checkout-core-fields.php
+++ b/includes/class-wcj-checkout-core-fields.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Checkout Core Fields
  *
- * @version 5.3.7
+ * @version 5.6.6
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
  */
@@ -80,7 +80,7 @@ if ( ! class_exists( 'WCJ_Checkout_Core_Fields' ) ) :
 		/**
 		 * Maybe_override_fields.
 		 *
-		 * @version 3.6.0
+		 * @version 5.6.6
 		 * @since   3.1.0
 		 * @todo    (maybe) add option to choose `$options_to_override`
 		 * @todo    (maybe) add to `$options_to_override`: enabled; class;
@@ -117,7 +117,7 @@ if ( ! class_exists( 'WCJ_Checkout_Core_Fields' ) ) :
 					$option_id     = ( isset( $option_data['option_id'] ) ? $option_data['option_id'] : $option );
 					$option_id     = 'wcj_checkout_fields_' . $field . '_' . $option_id;
 					$value         = wcj_get_option( $option_id, $default_value );
-					if ( $default_value !== $value ) {
+					if ( (string) $default_value !== $value ) {
 						$value                           = ( isset( $option_data['values'][ $value ] ) ? $option_data['values'][ $value ] : $value );
 						$fields[ $field_key ][ $option ] = $value;
 					}

--- a/includes/class-wcj-export-import.php
+++ b/includes/class-wcj-export-import.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Export
  *
- * @version 5.6.2
+ * @version 5.6.6
  * @since   2.5.4
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -203,7 +203,7 @@ if ( ! class_exists( 'WCJ_Export_Import' ) ) :
 		/**
 		 * Export_csv.
 		 *
-		 * @version 5.6.2
+		 * @version 5.6.6
 		 * @since   2.4.8
 		 */
 		public function export_csv() {
@@ -216,7 +216,10 @@ if ( ! class_exists( 'WCJ_Export_Import' ) ) :
 				if ( is_array( $data ) ) {
 					$csv = '';
 					foreach ( $data as $row ) {
-						$row  = $this->smart_format_fields( $row );
+						$row = $this->smart_format_fields( $row );
+						$row = implode(',', $row);
+						$row = trim(preg_replace('/\s+/', ' ', $row));
+						$row = explode(',', $row);
 						$csv .= implode( wcj_get_option( 'wcj_export_csv_separator', ',' ), $row ) . PHP_EOL;
 					}
 					if ( 'yes' === wcj_get_option( 'wcj_export_csv_add_utf_8_bom', 'yes' ) ) {

--- a/includes/class-wcj-multicurrency.php
+++ b/includes/class-wcj-multicurrency.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Multicurrency (Currency Switcher)
  *
- * @version 5.6.4
+ * @version 5.6.6
  * @since   2.4.3
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -952,7 +952,7 @@ if ( ! class_exists( 'WCJ_Multicurrency' ) ) :
 		/**
 		 * Updates min and max prices.
 		 *
-		 * @version 5.6.2
+		 * @version 5.6.6
 		 * @since   4.5.0
 		 *
 		 * @param int          $post_id defines the post_id.
@@ -996,7 +996,7 @@ if ( ! class_exists( 'WCJ_Multicurrency' ) ) :
 						$sale_price = get_post_meta( $product_id, '_wcj_multicurrency_per_product_sale_price_' . $currency_code, true );
 					}
 					$prices = array_filter( array( $regular_price, $sale_price ) );
-					$price  = count( $prices ) > 0 ? min( $prices ) : $original_price * $exchange_rate;
+					$price  = count( $prices ) > 0 ? min( $prices ) : (float) $original_price * (float) $exchange_rate;
 					$per_product_prices[ $currency_code ][ $product_id ] = $price;
 				}
 			}

--- a/includes/class-wcj-payment-gateways-min-max.php
+++ b/includes/class-wcj-payment-gateways-min-max.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Gateways Min/Max Amounts
  *
- * @version 5.6.2
+ * @version 5.6.6
  * @since   2.4.1
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
@@ -77,7 +77,7 @@ if ( ! class_exists( 'WCJ_Payment_Gateways_Min_Max' ) ) :
 		/**
 		 * Remove_payment_gateways.
 		 *
-		 * @version 5.6.2
+		 * @version 5.6.6
 		 * @since   4.7.0
 		 *
 		 * @param array $_available_gateways defines the _available_gateways.
@@ -112,12 +112,13 @@ if ( ! class_exists( 'WCJ_Payment_Gateways_Min_Max' ) ) :
 					}
 				}
 
-				if ( 0 !== $min && $total_in_cart < $min ) {
+				if ( '0' !== (string) $min && $total_in_cart < $min ) {
 					$notices[] = str_replace( array( '%gateway_title%', '%min_amount%' ), array( $gateway->title, wc_price( $min ) ), $notices_template_min );
 					unset( $_available_gateways[ $key ] );
 					continue;
 				}
-				if ( 0 !== $max && $total_in_cart > $max ) {
+				
+				if ( '0' !== (string) $max && $total_in_cart > $max ) {
 					$notices[] = str_replace( array( '%gateway_title%', '%max_amount%' ), array( $gateway->title, wc_price( $max ) ), $notices_template_max );
 					unset( $_available_gateways[ $key ] );
 					continue;

--- a/includes/class-wcj-price-labels.php
+++ b/includes/class-wcj-price-labels.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Module - Custom Price Labels
  *
- * @version 5.6.2
+ * @version 5.6.6
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/includes
  */
@@ -107,7 +107,7 @@ if ( ! class_exists( 'WCJ_Price_Labels' ) ) :
 		/**
 		 * Save_custom_price_labels.
 		 *
-		 * @version 5.6.2
+		 * @version 5.6.6
 		 * @param int            $post_id defines the post_id.
 		 * @param string | array $post defines the post.
 		 */
@@ -121,11 +121,11 @@ if ( ! class_exists( 'WCJ_Price_Labels' ) ) :
 					$option_name = $this->custom_tab_group_name . $custom_tab_section . $custom_tab_section_variation;
 					if ( '_text' === $custom_tab_section_variation ) {
 						if ( isset( $_POST[ $option_name ] ) ) {
-							! empty( update_post_meta( $post_id, '_' . $option_name, sanitize_text_field( wp_unslash( $_POST[ $option_name ] ) ) ) );
+							! empty( update_post_meta( $post_id, '_' . $option_name, wp_kses_post( wp_unslash( $_POST[ $option_name ] ) ) ) );
 						}
 					} else {
 						if ( isset( $_POST[ $option_name ] ) ) {
-							! empty( update_post_meta( $post_id, '_' . $option_name, sanitize_text_field( wp_unslash( $_POST[ $option_name ] ) ) ) );
+							! empty( update_post_meta( $post_id, '_' . $option_name, wp_kses_post( wp_unslash( $_POST[ $option_name ] ) ) ) );
 						} else {
 							update_post_meta( $post_id, '_' . $option_name, 'off' );
 						}

--- a/includes/reports/class-wcj-reports-product-sales-daily.php
+++ b/includes/reports/class-wcj-reports-product-sales-daily.php
@@ -174,7 +174,7 @@ if ( ! class_exists( 'WCJ_Reports_Product_Sales_Daily' ) ) :
 		/**
 		 * Output_report_header.
 		 *
-		 * @version 5.5.9
+		 * @version 5.6.6
 		 * @since   2.9.0
 		 */
 		public function output_report_header() {
@@ -203,11 +203,14 @@ if ( ! class_exists( 'WCJ_Reports_Product_Sales_Daily' ) ) :
 			if ( function_exists( 'wp_verify_nonce' ) ) {
 				$wpnonce = isset( $_REQUEST['_wpnonce'] ) ? wp_verify_nonce( sanitize_key( isset( $_REQUEST['_wpnonce'] ) ? $_REQUEST['_wpnonce'] : '' ) ) : true;
 			}
+			$pages        = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
+			$tabs         = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['tab'] ) ) : '';
+			$reports      = isset( $_GET['report'] ) ? sanitize_text_field( wp_unslash( $_GET['report'] ) ) : '';
 			$filter_form  = '';
 			$filter_form .= '<form method="get" action="">';
-			$filter_form .= '<input type="hidden" name="page" value="' . ( $wpnonce && ! empty( $_GET['page'] ) ) . '" />';
-			$filter_form .= '<input type="hidden" name="tab" value="' . ( $wpnonce && ! empty( $_GET['tab'] ) ) . '" />';
-			$filter_form .= '<input type="hidden" name="report" value="' . ( $wpnonce && ! empty( $_GET['report'] ) ) . '" />';
+			$filter_form .= '<input type="hidden" name="page" value="' . $pages . '" />';
+			$filter_form .= '<input type="hidden" name="tab" value="' . $tabs . '" />';
+			$filter_form .= '<input type="hidden" name="report" value="' . $reports . '" />';
 			$filter_form .= '<label style="font-style:italic;" for="start_date">' . __( 'From:', 'woocommerce-jetpack' ) . '</label> ' .
 			'<input type="text" display="date" dateformat="' . wcj_date_format_php_to_js( 'Y-m-d' ) . '" name="start_date" title="" value="' . $this->start_date . '" />';
 			$filter_form .= ' ';

--- a/langs/woocommerce-jetpack.pot
+++ b/langs/woocommerce-jetpack.pot
@@ -10,7 +10,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.3\n"
+"X-Generator: Poedit 2.0.6\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: __;_e;__ngettext:1,2;_n:1,2;__ngettext_noop:1,2;"
 "_n_noop:1,2;_c;_nc:4c,1,2;_x:1,2c;_nx:4c,1,2;_nx_noop:4c,1,2;_ex:1,2c;"
@@ -2398,32 +2398,32 @@ msgstr ""
 msgid "Export Products."
 msgstr ""
 
-#: includes/class-wcj-export-import.php:252
-#: includes/class-wcj-export-import.php:258
+#: includes/class-wcj-export-import.php:255
+#: includes/class-wcj-export-import.php:261
 msgid "Filter by Billing Country"
 msgstr ""
 
-#: includes/class-wcj-export-import.php:253
+#: includes/class-wcj-export-import.php:256
 msgid "Filter by Product Title"
 msgstr ""
 
-#: includes/class-wcj-export-import.php:272
-#: includes/reports/class-wcj-reports-product-sales-daily.php:219
+#: includes/class-wcj-export-import.php:275
+#: includes/reports/class-wcj-reports-product-sales-daily.php:222
 #: includes/reports/wcj-class-reports-sales-gateways.php:166
 #: includes/settings/wcj-settings-orders.php:48
 msgid "Filter"
 msgstr ""
 
-#: includes/class-wcj-export-import.php:304
+#: includes/class-wcj-export-import.php:307
 #: includes/class-wcj-track-users.php:45
 msgid "All time"
 msgstr ""
 
-#: includes/class-wcj-export-import.php:323
+#: includes/class-wcj-export-import.php:326
 msgid "Custom:"
 msgstr ""
 
-#: includes/class-wcj-export-import.php:328
+#: includes/class-wcj-export-import.php:331
 msgid "Go"
 msgstr ""
 
@@ -8865,38 +8865,38 @@ msgstr ""
 msgid "Reports Settings"
 msgstr ""
 
-#: includes/reports/class-wcj-reports-product-sales-daily.php:211
+#: includes/reports/class-wcj-reports-product-sales-daily.php:214
 #: includes/reports/wcj-class-reports-sales-gateways.php:160
 msgid "From:"
 msgstr ""
 
-#: includes/reports/class-wcj-reports-product-sales-daily.php:214
+#: includes/reports/class-wcj-reports-product-sales-daily.php:217
 #: includes/reports/wcj-class-reports-sales-gateways.php:163
 msgid "To:"
 msgstr ""
 
-#: includes/reports/class-wcj-reports-product-sales-daily.php:217
+#: includes/reports/class-wcj-reports-product-sales-daily.php:220
 msgid "Product:"
 msgstr ""
 
-#: includes/reports/class-wcj-reports-product-sales-daily.php:307
+#: includes/reports/class-wcj-reports-product-sales-daily.php:310
 #, php-format
 msgid "Total: %d"
 msgstr ""
 
-#: includes/reports/class-wcj-reports-product-sales-daily.php:312
-#: includes/reports/class-wcj-reports-product-sales-daily.php:317
+#: includes/reports/class-wcj-reports-product-sales-daily.php:315
+#: includes/reports/class-wcj-reports-product-sales-daily.php:320
 #, php-format
 msgid "Total: %s"
 msgstr ""
 
-#: includes/reports/class-wcj-reports-product-sales-daily.php:336
+#: includes/reports/class-wcj-reports-product-sales-daily.php:339
 #: includes/reports/wcj-class-reports-sales-gateways.php:196
 #, php-format
 msgid "Total orders: %d"
 msgstr ""
 
-#: includes/reports/class-wcj-reports-product-sales-daily.php:337
+#: includes/reports/class-wcj-reports-product-sales-daily.php:340
 #: includes/reports/class-wcj-reports-sales.php:400
 #: includes/reports/wcj-class-reports-sales-gateways.php:198
 msgid "No sales data for current period."

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce customization, woocommerce bundle, woocommerce product addon, 
 Requires at least: 4.4
 Tested up to: 6.0.2
 Requires PHP: 7.2
-Stable tag: 5.6.5
+Stable tag: 5.6.6
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -274,6 +274,17 @@ To unlock all Booster for WooCommerce features, please install additional paid B
 * For support please visit the [Plugin Support Forum](https://wordpress.org/support/plugin/woocommerce-jetpack/).
 
 == Changelog ==
+
+= 5.6.6 28/09/2022 =
+
+* FIXED - CART & CHECKOUT - Checkout Core Fields - Fixed checkout form design issues.
+* FIXED - PAYMENT GATEWAYS - Gateways Min/Max Amounts - Fixed showing all payment gateways notice on the checkout page.
+* FIXED - BUTTON & PRICE LABELS - Custom Price Labels- Escape the HTML content from the "per page product meta box" value.
+* FIXED - EMAILS & MISC. - Reports- Fixed date range filter on product sale report.
+* FIXED - EMAILS & MISC. - Export - Fixed export order line break issue in this module.
+FIXED - PHP Fatal error: Uncaught TypeError: Unsupported operand types: string in /includes/class-wcj-multicurrency.php...
+* WooCommerce 6.9.4 tested
+* WordPress 6.0.2 Tested
 
 = 5.6.5 12/09/2022 =
 

--- a/version-details.json
+++ b/version-details.json
@@ -1,6 +1,6 @@
 {
-    "0" : "= 5.6.5 12/09/2022 =",
-    "1" : "* FIXED - Fatal Error: Cannot redeclare _load_plugin_class()",
-    "2" : "* FIXED - Fatal Error: Uncaught TypeError: implode(): Argument #1 ($pieces)....tracking/class-plugin-usage-tracker.php:413",
-    "3" : "* FIXED - PHP Notice:  Undefined index: wcj-cat in includes/admin/class-wc-settings-jetpack.php on line 203"
+    "0" : "= 5.6.6 28/09/2022 =",
+    "1" : "* FIXED - CART & CHECKOUT - Checkout Core Fields - Fixed checkout form design issues.",
+    "2" : "* FIXED - PAYMENT GATEWAYS - Gateways Min/Max Amounts - Fixed showing all payment gateways notice on the checkout page.",
+    "3" : "* FIXED - BUTTON & PRICE LABELS - Custom Price Labels- Escape the HTML content from the 'per page product meta box' value."
 }

--- a/woocommerce-jetpack.php
+++ b/woocommerce-jetpack.php
@@ -3,13 +3,13 @@
  * Plugin Name: Booster for WooCommerce
  * Plugin URI: https://booster.io
  * Description: Supercharge your WooCommerce site with these awesome powerful features. More than 100 modules.All in one WooCommerce plugin.
- * Version: 5.6.5
+ * Version: 5.6.6
  * Author: Pluggabl LLC
  * Author URI: https://booster.io
  * Text Domain: woocommerce-jetpack
  * Domain Path: /langs
  * Copyright: © 2020 Pluggabl LLC.
- * WC tested up to: 6.8.2
+ * WC tested up to: 6.9.4
  * License: GNU General Public License v3.0
  * php version 7.2
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -65,7 +65,7 @@ if ( ! class_exists( 'WC_Jetpack' ) ) :
 		 * @var   string
 		 * @since 2.4.7
 		 */
-		public $version = '5.6.5';
+		public $version = '5.6.6';
 
 		/**
 		 * The single instance of the class


### PR DESCRIPTION
= 5.6.6 28/09/2022 =

* FIXED - CART & CHECKOUT - Checkout Core Fields - Fixed checkout form design issues.
* FIXED - PAYMENT GATEWAYS - Gateways Min/Max Amounts - Fixed showing all payment gateways notice on the checkout page.
* FIXED - BUTTON & PRICE LABELS - Custom Price Labels- Escape the HTML content from the "per page product meta box" value.
* FIXED - EMAILS & MISC. - Reports- Fixed date range filter on product sale report.
* FIXED - EMAILS & MISC. - Export - Fixed export order line break issue in this module.
FIXED - PHP Fatal error: Uncaught TypeError: Unsupported operand types: string in /includes/class-wcj-multicurrency.php...
* WooCommerce 6.9.4 tested
* WordPress 6.0.2 Tested