### PR TITLE
Branch v7.2.1 dev

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,15 @@
 == Changelog ==
 
+= 7.2.1 10/07/2024 =
+
+* FIXED - PRODUCTS - Tax Display - Hide the 'wcj-button-toggle-tax-display-nonce' nonce field to prevent it from breaking the WooCommerce REST API JSON response in certain instances.
+* FIXED - Fixed the cross-site scripting vulnerability issue associated with the shortcodes of the Cart category.
+* FIXED - Addressed cross-site scripting vulnerabilities associated with Product Input-field shortcodes.
+* FIXED - Rectified cross-site scripting vulnerabilities linked to the Add New Product '[wcj_product_add_new]' shortcode.
+* FIXED - PHP Fatal error: Uncaught Error: Call to a member function get_price() on bool in... wcj-functions-price-currency.php:616.
+* WooCommerce 9.0.2 Tested
+* WordPress 6.5.5 Tested
+
 = 7.2.0 05/06/2024 =
 
 * FIXED - PRODUCTS - User Products - Addressed the unauthenticated arbitrary shortcode execution vulnerability in the user product module.

--- a/includes/functions/wcj-functions-price-currency.php
+++ b/includes/functions/wcj-functions-price-currency.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Functions - Price and Currency
  *
- * @version 7.1.7
+ * @version 7.2.1
  * @since   2.7.0
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/functions
@@ -605,18 +605,18 @@ if ( ! function_exists( 'wc_get_product_purchase_price' ) ) {
 	/**
 	 * Wc_get_product_purchase_price.
 	 *
-	 * @version 7.1.7
+	 * @version 7.2.1
 	 * @param   int $product_id defines the product_id.
 	 */
 	function wc_get_product_purchase_price( $product_id = 0 ) {
 		if ( 0 === $product_id ) {
 			$product_id = get_the_ID();
 		}
-		$product       = wc_get_product( $product_id );
-		$product_price = ( isset( $product ) && $product->get_price() ) ? $product->get_price() : 0;
+		$product = wc_get_product( $product_id );
 		if ( ! $product ) {
 			return 0;
 		}
+		$product_price  = ( isset( $product ) && $product->get_price() ) ? $product->get_price() : 0;
 		$purchase_price = 0;
 		if ( 'yes' === wcj_get_option( 'wcj_purchase_price_enabled', 'yes' ) ) {
 			$purchase_price += (float) get_post_meta( $product_id, '_wcj_purchase_price', true );

--- a/includes/shortcodes/class-wcj-cart-shortcodes.php
+++ b/includes/shortcodes/class-wcj-cart-shortcodes.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Shortcodes - Cart
  *
- * @version 3.5.1
+ * @version 7.2.1
  * @since   3.5.1
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/shortcodes
@@ -17,7 +17,7 @@ if ( ! class_exists( 'WCJ_Cart_Shortcodes' ) ) :
 		/**
 		 * WCJ_Cart_Shortcodes.
 		 *
-		 * @version 3.5.1
+		 * @version 7.2.1
 		 * @since   3.5.1
 		 */
 	class WCJ_Cart_Shortcodes extends WCJ_Shortcodes {
@@ -25,7 +25,7 @@ if ( ! class_exists( 'WCJ_Cart_Shortcodes' ) ) :
 		/**
 		 * Constructor.
 		 *
-		 * @version 3.5.1
+		 * @version 7.2.1
 		 * @since   3.5.1
 		 * @todo    (maybe) add `$atts['multiply_by']` to (all) shortcodes
 		 */
@@ -49,10 +49,25 @@ if ( ! class_exists( 'WCJ_Cart_Shortcodes' ) ) :
 			);
 
 			$this->the_atts = array(
-				'multiply_by' => 1,
+				'multiply_by'   => 1,
+				'function_name' => null,
 			);
 
 			parent::__construct();
+
+		}
+
+		/**
+		 * Inits shortcode atts and properties.
+		 *
+		 * @version 7.2.1
+		 * @param   array $atts Shortcode atts.
+		 * @return  array The (modified) shortcode atts.
+		 */
+		public function init_atts( $atts ) {
+			$atts['function_name'] = wcj_sanitize_input_attribute_values( $atts['function_name'] );
+			$atts['multiply_by']   = (int) wcj_sanitize_input_attribute_values( $atts['multiply_by'] );
+			return $atts;
 
 		}
 

--- a/includes/shortcodes/class-wcj-general-shortcodes.php
+++ b/includes/shortcodes/class-wcj-general-shortcodes.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Shortcodes - General
  *
- * @version 7.1.9
+ * @version 7.2.1
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/shortcodes
  */
@@ -479,7 +479,7 @@ if ( ! class_exists( 'WCJ_General_Shortcodes' ) ) :
 		/**
 		 * Wcj_button_toggle_tax_display.
 		 *
-		 * @version 7.1.9
+		 * @version 7.2.1
 		 * @since   3.2.4
 		 * @todo    (dev) different style/class for different tax state
 		 * @todo    (maybe) `get` instead of `post`
@@ -490,7 +490,7 @@ if ( ! class_exists( 'WCJ_General_Shortcodes' ) ) :
 			$current_value = ( ( '' === $session_value || null === $session_value ) ? wcj_get_option( 'woocommerce_tax_display_shop', 'excl' ) : $session_value );
 			$current_value = '' === $current_value ? 'excl' : $current_value;
 			$label         = $atts[ 'label_' . $current_value ];
-			return '<form method="post" action="">' . wp_nonce_field( 'wcj_button_toggle_tax_display', 'wcj-button-toggle-tax-display-nonce' ) . '<input type="submit" name="wcj_button_toggle_tax_display"' .
+			return '<form method="post" action="">' . wp_nonce_field( 'wcj_button_toggle_tax_display', 'wcj-button-toggle-tax-display-nonce', true, false ) . '<input type="submit" name="wcj_button_toggle_tax_display"' .
 			' class="' . $atts['class'] . '" style="' . $atts['style'] . '" value="' . $label . '"></form>';
 		}
 

--- a/includes/shortcodes/class-wcj-input-field-shortcodes.php
+++ b/includes/shortcodes/class-wcj-input-field-shortcodes.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Shortcodes - Input Field
  *
- * @version 7.1.1
+ * @version 7.2.1
  * @since   2.5.2
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/shortcodes
@@ -17,7 +17,7 @@ if ( ! class_exists( 'WCJ_Input_Field_Shortcodes' ) ) :
 		/**
 		 * WCJ_Input_Field_Shortcodes.
 		 *
-		 * @version 3.0.1
+		 * @version 7.2.1
 		 * @since   2.5.2
 		 */
 	class WCJ_Input_Field_Shortcodes extends WCJ_Shortcodes {
@@ -25,7 +25,7 @@ if ( ! class_exists( 'WCJ_Input_Field_Shortcodes' ) ) :
 		/**
 		 * Constructor.
 		 *
-		 * @version 3.0.1
+		 * @version 7.2.1
 		 * @since   2.5.2
 		 */
 		public function __construct() {
@@ -35,14 +35,15 @@ if ( ! class_exists( 'WCJ_Input_Field_Shortcodes' ) ) :
 			);
 
 			$this->the_atts = array(
-				'type'        => 'text',
-				'class'       => '',
-				'value'       => '',
-				'placeholder' => '',
-				'name'        => '',
-				'attach_to'   => '',
-				'label'       => '',
-				'required'    => 'no',
+				'type'            => 'text',
+				'class'           => '',
+				'value'           => '',
+				'placeholder'     => '',
+				'name'            => '',
+				'attach_to'       => '',
+				'label'           => '',
+				'required'        => 'no',
+				'data_attributes' => null,
 			);
 
 			parent::__construct();
@@ -52,19 +53,23 @@ if ( ! class_exists( 'WCJ_Input_Field_Shortcodes' ) ) :
 		/**
 		 * Wcj_input_field.
 		 *
-		 * @version 7.1.1
+		 * @version 7.2.1
 		 * @since   2.5.2
 		 * @param array  $atts The user defined shortcode attributes.
 		 * @param string $content Optional. The content between the opening and closing shortcode tags. Default is an empty string.
 		 */
 		public function wcj_input_field( $atts, $content ) {
 
-			$type        = wcj_sanitize_input_attribute_values( $atts['type'] );
-			$class       = wcj_sanitize_input_attribute_values( $atts['class'] );
-			$name        = wcj_sanitize_input_attribute_values( $atts['name'] );
-			$label       = wcj_sanitize_input_attribute_values( $atts['label'] );
-			$value       = wcj_sanitize_input_attribute_values( $atts['value'] );
-			$placeholder = wcj_sanitize_input_attribute_values( $atts['placeholder'] );
+			$type                    = wcj_sanitize_input_attribute_values( $atts['type'] );
+			$class                   = wcj_sanitize_input_attribute_values( $atts['class'] );
+			$name                    = wcj_sanitize_input_attribute_values( $atts['name'] );
+			$label                   = wcj_sanitize_input_attribute_values( $atts['label'] );
+			$value                   = wcj_sanitize_input_attribute_values( $atts['value'] );
+			$atts['attach_to']       = wcj_sanitize_input_attribute_values( $atts['attach_to'] );
+			$placeholder             = wcj_sanitize_input_attribute_values( $atts['placeholder'] );
+			$atts['required']        = wcj_sanitize_input_attribute_values( $atts['required'] );
+			$atts['name_array']      = wcj_sanitize_input_attribute_values( $atts['name_array'] );
+			$atts['data_attributes'] = wcj_sanitize_input_attribute_values( $atts['data_attributes'], 'restrict_quotes' );
 			if ( '' === $name ) {
 				return __( 'Attribute "name" is required!', 'woocommerce-jetpack' );
 			}

--- a/includes/shortcodes/class-wcj-products-add-form-shortcodes.php
+++ b/includes/shortcodes/class-wcj-products-add-form-shortcodes.php
@@ -2,7 +2,7 @@
 /**
  * Booster for WooCommerce - Shortcodes - Products Add Form
  *
- * @version 7.1.8
+ * @version 7.2.1
  * @since   2.5.0
  * @author  Pluggabl LLC.
  * @package Booster_For_WooCommerce/shortcodes
@@ -73,6 +73,46 @@ if ( ! class_exists( 'WCJ_Products_Add_Form_Shortcodes' ) ) :
 			}
 
 			parent::__construct();
+		}
+
+		/**
+		 * Init_atts.
+		 *
+		 * @version 7.2.1
+		 * @param array $atts The user defined shortcode attributes.
+		 */
+		public function init_atts( $atts ) {
+			$atts['product_id']              = (int) wcj_sanitize_input_attribute_values( $atts['product_id'] );
+			$atts['post_status']             = wcj_sanitize_input_attribute_values( $atts['post_status'] );
+			$atts['desc_enabled']            = wcj_sanitize_input_attribute_values( $atts['desc_enabled'] );
+			$atts['short_desc_enabled']      = wcj_sanitize_input_attribute_values( $atts['short_desc_enabled'] );
+			$atts['regular_price_enabled']   = wcj_sanitize_input_attribute_values( $atts['regular_price_enabled'] );
+			$atts['sale_price_enabled']      = wcj_sanitize_input_attribute_values( $atts['sale_price_enabled'] );
+			$atts['external_url_enabled']    = wcj_sanitize_input_attribute_values( $atts['external_url_enabled'] );
+			$atts['cats_enabled']            = wcj_sanitize_input_attribute_values( $atts['cats_enabled'] );
+			$atts['tags_enabled']            = wcj_sanitize_input_attribute_values( $atts['tags_enabled'] );
+			$atts['image_gallery_enabled']   = wcj_sanitize_input_attribute_values( $atts['image_gallery_enabled'] );
+			$atts['image_enabled']           = wcj_sanitize_input_attribute_values( $atts['image_enabled'] );
+			$atts['desc_required']           = wcj_sanitize_input_attribute_values( $atts['desc_required'] );
+			$atts['short_desc_required']     = wcj_sanitize_input_attribute_values( $atts['short_desc_required'] );
+			$atts['regular_price_required']  = wcj_sanitize_input_attribute_values( $atts['regular_price_required'] );
+			$atts['sale_price_required']     = wcj_sanitize_input_attribute_values( $atts['sale_price_required'] );
+			$atts['external_url_required']   = wcj_sanitize_input_attribute_values( $atts['external_url_required'] );
+			$atts['cats_required']           = wcj_sanitize_input_attribute_values( $atts['cats_required'] );
+			$atts['tags_required']           = wcj_sanitize_input_attribute_values( $atts['tags_required'] );
+			$atts['image_required']          = wcj_sanitize_input_attribute_values( $atts['image_required'] );
+			$atts['image_gallery_required']  = wcj_sanitize_input_attribute_values( $atts['image_gallery_required'] );
+			$atts['visibility']              = wcj_sanitize_input_attribute_values( $atts['visibility'], 'restrict_quotes' );
+			$atts['module']                  = wcj_sanitize_input_attribute_values( $atts['module'] );
+			$atts['module_name']             = wcj_sanitize_input_attribute_values( $atts['module_name'] );
+			$atts['custom_taxonomies_total'] = wcj_sanitize_input_attribute_values( $atts['custom_taxonomies_total'] );
+			for ( $i = 1; $i <= $atts['custom_taxonomies_total']; $i++ ) {
+				$atts[ 'custom_taxonomy_' . $i . '_enabled' ]  = wcj_sanitize_input_attribute_values( $atts[ 'custom_taxonomy_' . $i . '_enabled' ] );
+				$atts[ 'custom_taxonomy_' . $i . '_required' ] = wcj_sanitize_input_attribute_values( $atts[ 'custom_taxonomy_' . $i . '_required' ] );
+				$atts[ 'custom_taxonomy_' . $i . '_id' ]       = wcj_sanitize_input_attribute_values( $atts[ 'custom_taxonomy_' . $i . '_id' ] );
+				$atts[ 'custom_taxonomy_' . $i . '_title' ]    = wcj_sanitize_input_attribute_values( $atts[ 'custom_taxonomy_' . $i . '_title' ] );
+			}
+			return $atts;
 		}
 
 		/**

--- a/langs/woocommerce-jetpack.pot
+++ b/langs/woocommerce-jetpack.pot
@@ -220,8 +220,8 @@ msgstr ""
 #: includes/settings/wcj-settings-checkout-custom-fields.php:213
 #: includes/settings/wcj-settings-eu-vat-number.php:55
 #: includes/settings/wcj-settings-product-by-user.php:16
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:190
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:426
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:230
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:466
 msgid "Description"
 msgstr ""
 
@@ -1675,16 +1675,16 @@ msgstr ""
 #: includes/export/class-wcj-export-fields-helper.php:322
 #: includes/settings/wcj-settings-product-by-user.php:22
 #: includes/settings/wcj-settings-sku.php:29
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:196
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:490
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:236
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:530
 msgid "Categories"
 msgstr ""
 
 #: includes/class-wcj-admin-bar.php:518
 #: includes/export/class-wcj-export-fields-helper.php:323
 #: includes/settings/wcj-settings-product-by-user.php:23
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:197
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:500
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:237
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:540
 msgid "Tags"
 msgstr ""
 
@@ -3093,7 +3093,7 @@ msgstr ""
 #: includes/class-wcj-product-by-user.php:309
 #: includes/pdf-invoices/submodules/class-wcj-pdf-invoicing-display.php:169
 #: includes/pdf-invoices/submodules/class-wcj-pdf-invoicing-display.php:438
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:448
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:488
 #: includes/tools/class-wcj-order-statuses-tool.php:225
 msgid "Delete"
 msgstr ""
@@ -4357,7 +4357,7 @@ msgstr ""
 #: includes/reports/class-wcj-reports-monthly-sales.php:396
 #: includes/reports/class-wcj-reports-monthly-sales.php:702
 #: includes/settings/wcj-settings-empty-cart.php:103
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:448
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:488
 #: includes/tools/class-wcj-order-statuses-tool.php:225
 #: includes/tools/class-wcj-order-statuses-tool.php:381
 msgid "Are you sure?"
@@ -4768,7 +4768,7 @@ msgstr ""
 #: includes/settings/wcj-settings-upsells.php:60
 #: includes/shipping/class-wc-shipping-wcj-custom-template.php:156
 #: includes/shipping/class-wc-shipping-wcj-custom-with-shipping-zones.php:272
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:418
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:458
 #: includes/widgets/class-wcj-widget-country-switcher.php:80
 #: includes/widgets/class-wcj-widget-left-to-free-shipping.php:66
 #: includes/widgets/class-wcj-widget-multicurrency.php:85
@@ -4777,7 +4777,7 @@ msgid "Title"
 msgstr ""
 
 #: includes/class-wcj-product-by-user.php:300
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:527
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:567
 #: includes/tools/class-wcj-order-statuses-tool.php:240
 #: includes/tools/class-wcj-order-statuses-tool.php:318
 msgid "Edit"
@@ -5702,7 +5702,7 @@ msgstr ""
 #: includes/settings/wcj-settings-purchase-data.php:249
 #: includes/settings/wcj-settings-sku.php:339
 #: includes/settings/wcj-settings-sku.php:366
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:527
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:567
 #: includes/tools/class-wcj-order-statuses-tool.php:318
 msgid "Add"
 msgstr ""
@@ -6869,8 +6869,8 @@ msgstr ""
 #: includes/settings/meta-box/wcj-settings-meta-box-multicurrency.php:44
 #: includes/settings/meta-box/wcj-settings-meta-box-price-by-user-role.php:108
 #: includes/settings/wcj-settings-product-by-user.php:19
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:193
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:462
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:233
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:502
 msgid "Regular Price"
 msgstr ""
 
@@ -6879,8 +6879,8 @@ msgstr ""
 #: includes/settings/meta-box/wcj-settings-meta-box-multicurrency.php:53
 #: includes/settings/meta-box/wcj-settings-meta-box-price-by-user-role.php:117
 #: includes/settings/wcj-settings-product-by-user.php:20
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:194
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:471
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:234
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:511
 msgid "Sale Price"
 msgstr ""
 
@@ -6909,8 +6909,8 @@ msgstr ""
 
 #: includes/export/class-wcj-export-fields-helper.php:296
 #: includes/settings/wcj-settings-product-by-user.php:17
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:191
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:435
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:231
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:475
 msgid "Short Description"
 msgstr ""
 
@@ -11048,7 +11048,7 @@ msgid "Or"
 msgstr ""
 
 #: includes/settings/wcj-settings-checkout-core-fields.php:118
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:411
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:451
 msgid "required"
 msgstr ""
 
@@ -18202,8 +18202,8 @@ msgid "Replaceable value:"
 msgstr ""
 
 #: includes/settings/wcj-settings-product-by-user.php:18
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:192
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:454
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:232
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:494
 msgid "Image"
 msgstr ""
 
@@ -18256,7 +18256,7 @@ msgid "Message: Product Successfully Added"
 msgstr ""
 
 #: includes/settings/wcj-settings-product-by-user.php:146
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:371
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:411
 msgid "\"%product_title%\" successfully added!"
 msgstr ""
 
@@ -18265,7 +18265,7 @@ msgid "Message: Product Successfully Edited"
 msgstr ""
 
 #: includes/settings/wcj-settings-product-by-user.php:153
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:379
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:419
 msgid "\"%product_title%\" successfully edited!"
 msgstr ""
 
@@ -21665,7 +21665,7 @@ msgstr ""
 msgid "Tax toggle (excl.)"
 msgstr ""
 
-#: includes/shortcodes/class-wcj-input-field-shortcodes.php:69
+#: includes/shortcodes/class-wcj-input-field-shortcodes.php:74
 msgid "Attribute \"name\" is required!"
 msgstr ""
 
@@ -21678,42 +21678,42 @@ msgstr ""
 msgid "Product by User"
 msgstr ""
 
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:177
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:217
 msgid "Title is required!"
 msgstr ""
 
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:185
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:225
 msgid "Product exists!"
 msgstr ""
 
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:195
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:480
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:235
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:520
 msgid "Product URL"
 msgstr ""
 
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:212
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:252
 #, php-format
 msgid "%s is required!"
 msgstr ""
 
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:218
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:258
 msgid "Sale price must be less than the regular price!"
 msgstr ""
 
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:230
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:241
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:270
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:281
 msgid "Sorry, only JPG, JPEG, PNG, WEBP, HEIC, HEIF and GIF files are allowed"
 msgstr ""
 
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:363
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:403
 msgid "Error!"
 msgstr ""
 
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:406
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:446
 msgid "Add New Product"
 msgstr ""
 
-#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:406
+#: includes/shortcodes/class-wcj-products-add-form-shortcodes.php:446
 msgid "Edit Product"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: pluggabl
 Tags: woocommerce customization, woocommerce bundle, woocommerce product addon, woocommerce integration, ecommerce plugin
 Requires at least: 5.8
-Tested up to: 6.5.3
+Tested up to: 6.5.5
 Requires PHP: 7.2
-Stable tag: 7.2.0
+Stable tag: 7.2.1
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -246,10 +246,14 @@ To unlock all Booster for WooCommerce features, please install additional paid B
 
 == Changelog ==
 
-= 7.2.0 05/06/2024 =
+= 7.2.1 10/07/2024 =
 
-* FIXED - PRODUCTS - User Products - Addressed the unauthenticated arbitrary shortcode execution vulnerability in the user product module.
-* WooCommerce 8.9.1 Tested
-* WordPress 6.5.3 Tested
+* FIXED - PRODUCTS - Tax Display - Hide the 'wcj-button-toggle-tax-display-nonce' nonce field to prevent it from breaking the WooCommerce REST API JSON response in certain instances.
+* FIXED - Fixed the cross-site scripting vulnerability issue associated with the shortcodes of the Cart category.
+* FIXED - Addressed cross-site scripting vulnerabilities associated with Product Input-field shortcodes.
+* FIXED - Rectified cross-site scripting vulnerabilities linked to the Add New Product '[wcj_product_add_new]' shortcode.
+* FIXED - PHP Fatal error: Uncaught Error: Call to a member function get_price() on bool in... wcj-functions-price-currency.php:616.
+* WooCommerce 9.0.2 Tested
+* WordPress 6.5.5 Tested
 
 [See changelog for all versions](https://raw.githubusercontent.com/pluggabl/woocommerce-jetpack/master/changelog.txt).

--- a/version-details.json
+++ b/version-details.json
@@ -1,6 +1,7 @@
 {
-    "0" : "= 7.2.0 05/06/2024 =",
-    "1" : "* FIXED - PRODUCTS - User Products - Addressed the unauthenticated arbitrary shortcode execution vulnerability in the user product module.",
-    "2" : "* WooCommerce 8.9.1 Tested",
-    "3" : "* WordPress 6.5.3 Tested"
+    "0" : "= 7.2.1 10/07/2024 =",
+    "1" : "* FIXED - PRODUCTS - Tax Display - Hide the 'wcj-button-toggle-tax-display-nonce' nonce field to prevent it from breaking the WooCommerce REST API JSON response in certain instances.",
+    "2" : "* FIXED - Fixed the cross-site scripting vulnerability issue associated with the shortcodes of the Cart category.",
+    "3" : "* WooCommerce 9.0.2 Tested",
+    "4" : "* WordPress 6.5.5 Tested"
 }

--- a/woocommerce-jetpack.php
+++ b/woocommerce-jetpack.php
@@ -4,7 +4,7 @@
  * Requires Plugins: woocommerce
  * Plugin URI: https://booster.io
  * Description: Supercharge your WooCommerce site with these awesome powerful features. More than 100 modules.All in one WooCommerce plugin.
- * Version: 7.2.0
+ * Version: 7.2.1
  * Author: Pluggabl LLC
  * Author URI: https://booster.io
  * Text Domain: woocommerce-jetpack
@@ -76,7 +76,7 @@ if ( ! class_exists( 'WC_Jetpack' ) ) :
 		 * @var   string
 		 * @since 2.4.7
 		 */
-		public $version = '7.2.0';
+		public $version = '7.2.1';
 
 		/**
 		 * The single instance of the class

--- a/woocommerce-jetpack.php
+++ b/woocommerce-jetpack.php
@@ -10,7 +10,7 @@
  * Text Domain: woocommerce-jetpack
  * Domain Path: /langs
  * Copyright: © 2020 Pluggabl LLC.
- * WC tested up to: 8.9.1
+ * WC tested up to: 9.0.2
  * License: GNU General Public License v3.0
  * php version 7.2
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
= 7.2.1 10/07/2024 =

* FIXED - PRODUCTS - Tax Display - Hide the 'wcj-button-toggle-tax-display-nonce' nonce field to prevent it from breaking the WooCommerce REST API JSON response in certain instances.
* FIXED - Fixed the cross-site scripting vulnerability issue associated with the shortcodes of the Cart category.
* FIXED - Addressed cross-site scripting vulnerabilities associated with Product Input-field shortcodes.
* FIXED - Rectified cross-site scripting vulnerabilities linked to the Add New Product '[wcj_product_add_new]' shortcode.
* FIXED - PHP Fatal error: Uncaught Error: Call to a member function get_price() on bool in... wcj-functions-price-currency.php:616.
* WooCommerce 9.0.2 Tested
* WordPress 6.5.5 Tested